### PR TITLE
Add admin middleware and tests

### DIFF
--- a/guhso-backend/app/Http/Kernel.php
+++ b/guhso-backend/app/Http/Kernel.php
@@ -64,5 +64,6 @@ class Kernel extends HttpKernel
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'admin' => \App\Http\Middleware\CheckAdmin::class,
     ];
 }

--- a/guhso-backend/app/Http/Middleware/CheckAdmin.php
+++ b/guhso-backend/app/Http/Middleware/CheckAdmin.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckAdmin
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        if (!$user || $user->role !== 'admin') {
+            abort(403, 'Forbidden');
+        }
+
+        return $next($request);
+    }
+}

--- a/guhso-backend/app/Providers/RouteServiceProvider.php
+++ b/guhso-backend/app/Providers/RouteServiceProvider.php
@@ -38,7 +38,7 @@ class RouteServiceProvider extends ServiceProvider
             ->group(base_path('routes/web.php'));
 
             // Add this for admin routes if you create a separate file
-            Route::middleware(['web', 'auth'])
+            Route::middleware(['web', 'auth', 'admin'])
                 ->namespace('App\Http\Controllers\Admin')
                 ->prefix('admin')
                 ->group(base_path('routes/admin.php'));

--- a/guhso-backend/database/migrations/2025_07_27_180740_add_role_to_users_table.php
+++ b/guhso-backend/database/migrations/2025_07_27_180740_add_role_to_users_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('users', function (Blueprint $table) {
-            //
+            $table->string('role')->default('user');
         });
     }
 
@@ -22,7 +22,8 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('users', function (Blueprint $table) {
-            //
+            $table->dropColumn('role');
         });
     }
 };
+

--- a/guhso-backend/routes/admin.php
+++ b/guhso-backend/routes/admin.php
@@ -3,5 +3,8 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Admin\ShowController;
 
-Route::get('/', [ShowController::class, 'index']);
-// Add other admin routes here
+Route::middleware('admin')->group(function () {
+    Route::get('/', [ShowController::class, 'index']);
+    // Add other admin routes here
+});
+

--- a/guhso-backend/tests/Feature/AdminMiddlewareTest.php
+++ b/guhso-backend/tests/Feature/AdminMiddlewareTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminMiddlewareTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_access_admin_dashboard(): void
+    {
+        $user = User::factory()->create();
+        $user->role = 'admin';
+        $user->save();
+
+        $response = $this->actingAs($user)->get('/admin/dashboard');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_non_admin_is_denied_access_to_admin_dashboard(): void
+    {
+        $user = User::factory()->create();
+        $user->role = 'user';
+        $user->save();
+
+        $response = $this->actingAs($user)->get('/admin/dashboard');
+
+        $response->assertStatus(403);
+    }
+}
+


### PR DESCRIPTION
## Summary
- create `CheckAdmin` middleware to restrict access to admin routes
- register the middleware alias `admin`
- secure admin route registration and admin route file
- add migration for user `role` column
- test access control for admin dashboard

## Testing
- `php artisan test` *(fails: vendor autoload not found)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688a8a03e7808326bc7c5f471d47eea8