### PR TITLE
Point auth redirects to dashboard

### DIFF
--- a/guhso-backend/app/Http/Controllers/Auth/ConfirmPasswordController.php
+++ b/guhso-backend/app/Http/Controllers/Auth/ConfirmPasswordController.php
@@ -25,7 +25,7 @@ class ConfirmPasswordController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = '/home';
+    protected $redirectTo = '/dashboard';
 
     /**
      * Create a new controller instance.

--- a/guhso-backend/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/guhso-backend/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -25,5 +25,5 @@ class ResetPasswordController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = '/home';
+    protected $redirectTo = '/dashboard';
 }

--- a/guhso-backend/app/Http/Controllers/Auth/VerificationController.php
+++ b/guhso-backend/app/Http/Controllers/Auth/VerificationController.php
@@ -25,7 +25,7 @@ class VerificationController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = '/home';
+    protected $redirectTo = '/dashboard';
 
     /**
      * Create a new controller instance.

--- a/guhso-backend/app/Providers/RouteServiceProvider.php
+++ b/guhso-backend/app/Providers/RouteServiceProvider.php
@@ -17,7 +17,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    public const HOME = '/home';
+    public const HOME = '/dashboard';
 
     /**
      * Define your route model bindings, pattern filters, and other route configuration.

--- a/guhso-backend/resources/views/welcome.blade.php
+++ b/guhso-backend/resources/views/welcome.blade.php
@@ -20,7 +20,7 @@
             @if (Route::has('login'))
                 <div class="sm:fixed sm:top-0 sm:right-0 p-6 text-right z-10">
                     @auth
-                        <a href="{{ url('/home') }}" class="font-semibold text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Home</a>
+                        <a href="{{ url('/dashboard') }}" class="font-semibold text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Home</a>
                     @else
                         <a href="{{ route('login') }}" class="font-semibold text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500">Log in</a>
 


### PR DESCRIPTION
## Summary
- change default home path to `/dashboard`
- redirect password and verification controllers to the dashboard
- update welcome page link to use the dashboard

## Testing
- `php artisan test` *(fails: missing vendor directory)*

------
https://chatgpt.com/codex/tasks/task_e_688ae2eda87483268fc7911b44e40393