### PR TITLE
Add blog posts API and React integration

### DIFF
--- a/guhso-backend/app/Http/Controllers/Api/PostController.php
+++ b/guhso-backend/app/Http/Controllers/Api/PostController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Post;
+use Illuminate\Http\Request;
+
+class PostController extends Controller
+{
+    public function index()
+    {
+        return response()->json(Post::latest()->paginate(10));
+    }
+
+    public function featured()
+    {
+        return response()->json(Post::where('is_featured', true)->latest()->get());
+    }
+
+    public function store(Request $request)
+    {
+        $request->validate([
+            'title' => 'required|string|max:255',
+            'body' => 'required|string',
+            'is_featured' => 'boolean',
+        ]);
+
+        $post = Post::create($request->only(['title', 'body', 'is_featured']));
+
+        return response()->json($post, 201);
+    }
+
+    public function show(Post $post)
+    {
+        return response()->json($post);
+    }
+
+    public function update(Request $request, Post $post)
+    {
+        $request->validate([
+            'title' => 'sometimes|string|max:255',
+            'body' => 'sometimes|string',
+            'is_featured' => 'sometimes|boolean',
+        ]);
+
+        $post->update($request->only(['title', 'body', 'is_featured']));
+
+        return response()->json($post);
+    }
+
+    public function destroy(Post $post)
+    {
+        $post->delete();
+        return response()->json(['message' => 'Post deleted']);
+    }
+}

--- a/guhso-backend/app/Models/Post.php
+++ b/guhso-backend/app/Models/Post.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'title',
+        'body',
+        'is_featured',
+    ];
+}

--- a/guhso-backend/database/migrations/2025_07_31_010000_create_posts_table.php
+++ b/guhso-backend/database/migrations/2025_07_31_010000_create_posts_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->text('body');
+            $table->boolean('is_featured')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('posts');
+    }
+};

--- a/guhso-backend/routes/api.php
+++ b/guhso-backend/routes/api.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Api\ShowController as ApiShowController;
 use App\Http\Controllers\Api\EpisodeController as ApiEpisodeController;
 use App\Http\Controllers\Api\FavoriteController;
 use App\Http\Controllers\Api\CommentController;
+use App\Http\Controllers\Api\PostController;
 use App\Http\Controllers\SearchController; 
 use Illuminate\Support\Facades\Route;
 
@@ -25,6 +26,14 @@ Route::prefix('v1')->group(function () {
     // Search endpoints
     Route::get('/search', [SearchController::class, 'api']);
     Route::get('/popular-tags', [SearchController::class, 'popularTags']);
+
+    // Blog posts
+    Route::get('/posts', [PostController::class, 'index']);
+    Route::get('/posts/featured', [PostController::class, 'featured']);
+    Route::post('/posts', [PostController::class, 'store']);
+    Route::get('/posts/{post}', [PostController::class, 'show']);
+    Route::put('/posts/{post}', [PostController::class, 'update']);
+    Route::delete('/posts/{post}', [PostController::class, 'destroy']);
     
     // Categories for navigation
     Route::get('/categories', function() {

--- a/guhso-podcast-react/__mocks__/axios.js
+++ b/guhso-podcast-react/__mocks__/axios.js
@@ -1,0 +1,4 @@
+module.exports = {
+  get: jest.fn(() => Promise.resolve({ data: [] })),
+  post: jest.fn(() => Promise.resolve({ data: {} })),
+};

--- a/guhso-podcast-react/src/App.js
+++ b/guhso-podcast-react/src/App.js
@@ -1,10 +1,11 @@
 // src/App.js
-import React, { useState } from 'react';
+import React from 'react';
 import Navbar from './components/Layout/Navbar';
 import HeroSection from './components/Hero/HeroSection';
 import TwoColumnSection from './components/Layout/TwoColumnSection';
 import Sidebar from './components/Sidebar/Sidebar';
 import FloatingPlayer from './components/Player/FloatingPlayer';
+import PostForm from './components/Posts/PostForm';
 import { PlayerProvider } from './contexts/PlayerContext';
 import './App.css';
 
@@ -16,6 +17,7 @@ function App() {
         <div className="main-container">
           <div className="left-section">
             <HeroSection />
+            <PostForm />
             <TwoColumnSection />
           </div>
           <Sidebar />

--- a/guhso-podcast-react/src/App.test.js
+++ b/guhso-podcast-react/src/App.test.js
@@ -1,8 +1,8 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
+import { render } from '@testing-library/react';
+jest.mock('axios');
+const App = require('./App').default;
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+test('renders without crashing', () => {
+  const { container } = render(<App />);
+  expect(container.querySelector('.App')).toBeInTheDocument();
 });

--- a/guhso-podcast-react/src/api.js
+++ b/guhso-podcast-react/src/api.js
@@ -1,0 +1,15 @@
+const API_URL = process.env.REACT_APP_API_URL;
+
+export async function fetchFeaturedPosts() {
+  const res = await fetch(`${API_URL}/posts/featured`);
+  return res.json();
+}
+
+export async function createPost(post) {
+  const res = await fetch(`${API_URL}/posts`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(post),
+  });
+  return res.json();
+}

--- a/guhso-podcast-react/src/components/Posts/PostForm.js
+++ b/guhso-podcast-react/src/components/Posts/PostForm.js
@@ -1,0 +1,57 @@
+// src/components/Posts/PostForm.js
+import React, { useState } from 'react';
+import { createPost } from '../../api';
+
+const PostForm = () => {
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [isFeatured, setIsFeatured] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await createPost({ title, body, is_featured: isFeatured });
+      setTitle('');
+      setBody('');
+      setIsFeatured(false);
+      alert('Post created');
+    } catch (err) {
+      console.error(err);
+      alert('Failed to create post');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={{ marginBottom: '2rem' }}>
+      <h3>Create Post</h3>
+      <div>
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Title"
+          required
+        />
+      </div>
+      <div>
+        <textarea
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          placeholder="Body"
+          required
+        />
+      </div>
+      <label>
+        <input
+          type="checkbox"
+          checked={isFeatured}
+          onChange={(e) => setIsFeatured(e.target.checked)}
+        />
+        Featured
+      </label>
+      <button type="submit">Submit</button>
+    </form>
+  );
+};
+
+export default PostForm;

--- a/guhso-podcast-react/src/components/Sidebar/FeaturedSection.js
+++ b/guhso-podcast-react/src/components/Sidebar/FeaturedSection.js
@@ -1,34 +1,25 @@
 // src/components/Sidebar/FeaturedSection.js
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { fetchFeaturedPosts } from '../../api';
 import './FeaturedSection.css';
 
 const FeaturedSection = () => {
   const [activeDot, setActiveDot] = useState(0);
-  
-  const featuredItems = [
-    {
-      id: 1,
-      title: "Featured Show",
-      name: "Tech Talks Daily",
-      description: "Your daily dose of tech news and insights"
-    },
-    {
-      id: 2,
-      title: "Trending",
-      name: "Design Weekly",
-      description: "Latest trends in UI/UX design"
-    },
-    {
-      id: 3,
-      title: "Popular",
-      name: "Business Insights",
-      description: "Entrepreneurship and startup stories"
-    }
-  ];
+  const [featuredItems, setFeaturedItems] = useState([]);
+
+  useEffect(() => {
+    fetchFeaturedPosts()
+      .then(setFeaturedItems)
+      .catch((err) => console.error(err));
+  }, []);
 
   const handleDotClick = (index) => {
     setActiveDot(index);
   };
+
+  if (!featuredItems.length) {
+    return null;
+  }
 
   return (
     <div className="featured-section">


### PR DESCRIPTION
## Summary
- add Post model, controller, migration and API routes
- fetch featured posts in the sidebar
- provide a post creation form in the React app
- add helper api wrapper
- update tests to work without axios

## Testing
- `npm test --prefix guhso-podcast-react --silent`
- `php artisan test` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688cd6a93adc8326900a5eb9a84efa95