### PR TITLE
feat: add blog post creation and listing

### DIFF
--- a/guhso-podcast-react/src/App.js
+++ b/guhso-podcast-react/src/App.js
@@ -1,15 +1,32 @@
 // src/App.js
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Navbar from './components/Layout/Navbar';
 import HeroSection from './components/Hero/HeroSection';
 import TwoColumnSection from './components/Layout/TwoColumnSection';
 import Sidebar from './components/Sidebar/Sidebar';
 import FloatingPlayer from './components/Player/FloatingPlayer';
 import PostForm from './components/Posts/PostForm';
+import PostList from './components/Posts/PostList';
+import { fetchPosts } from './api';
 import { PlayerProvider } from './contexts/PlayerContext';
 import './App.css';
 
 function App() {
+  const [posts, setPosts] = useState([]);
+
+  const loadPosts = async () => {
+    try {
+      const data = await fetchPosts();
+      setPosts(data.data || data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  useEffect(() => {
+    loadPosts();
+  }, []);
+
   return (
     <PlayerProvider>
       <div className="App">
@@ -17,7 +34,8 @@ function App() {
         <div className="main-container">
           <div className="left-section">
             <HeroSection />
-            <PostForm />
+            <PostForm onPostCreated={loadPosts} />
+            <PostList posts={posts} />
             <TwoColumnSection />
           </div>
           <Sidebar />

--- a/guhso-podcast-react/src/api.js
+++ b/guhso-podcast-react/src/api.js
@@ -5,6 +5,11 @@ export async function fetchFeaturedPosts() {
   return res.json();
 }
 
+export async function fetchPosts() {
+  const res = await fetch(`${API_URL}/posts`);
+  return res.json();
+}
+
 export async function createPost(post) {
   const res = await fetch(`${API_URL}/posts`, {
     method: 'POST',

--- a/guhso-podcast-react/src/components/Posts/PostForm.js
+++ b/guhso-podcast-react/src/components/Posts/PostForm.js
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 import { createPost } from '../../api';
 
-const PostForm = () => {
+const PostForm = ({ onPostCreated }) => {
   const [title, setTitle] = useState('');
   const [body, setBody] = useState('');
   const [isFeatured, setIsFeatured] = useState(false);
@@ -10,10 +10,13 @@ const PostForm = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      await createPost({ title, body, is_featured: isFeatured });
+      const newPost = await createPost({ title, body, is_featured: isFeatured });
       setTitle('');
       setBody('');
       setIsFeatured(false);
+      if (onPostCreated) {
+        onPostCreated(newPost);
+      }
       alert('Post created');
     } catch (err) {
       console.error(err);

--- a/guhso-podcast-react/src/components/Posts/PostList.js
+++ b/guhso-podcast-react/src/components/Posts/PostList.js
@@ -1,0 +1,22 @@
+// src/components/Posts/PostList.js
+import React from 'react';
+
+const PostList = ({ posts }) => {
+  if (!posts || posts.length === 0) {
+    return null;
+  }
+
+  return (
+    <div style={{ marginBottom: '2rem' }}>
+      <h3>Blog Posts</h3>
+      {posts.map((post) => (
+        <div key={post.id} style={{ marginBottom: '1rem' }}>
+          <h4>{post.title}</h4>
+          <p>{post.body}</p>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default PostList;

--- a/guhso-podcast-react/src/components/Sidebar/FeaturedSection.js
+++ b/guhso-podcast-react/src/components/Sidebar/FeaturedSection.js
@@ -21,14 +21,15 @@ const FeaturedSection = () => {
     return null;
   }
 
+  const activePost = featuredItems[activeDot];
+
   return (
     <div className="featured-section">
       <div className="featured-slider">
         <div className="featured-card">
           <div>
-            <h3>{featuredItems[activeDot].title}</h3>
-            <h2>{featuredItems[activeDot].name}</h2>
-            <p>{featuredItems[activeDot].description}</p>
+            <h3>{activePost.title}</h3>
+            <p>{activePost.body}</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add API and UI to fetch and display blog posts
- allow dashboard blog form to trigger refresh after saving
- show featured blog content in sidebar

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing and composer install requires GitHub token)*
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_688e63ba66288326b8523194844ddb92