### PR TITLE
feat: add blog post creation in dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 - ❤️ **Favorites System** - Save and organize your preferred episodes
 - 💬 **Comments** - Engage with content and community
 - 📝 **Blog Integration** - Rich content beyond just audio
+- ✍️ **Blog Management** - Create and publish posts from the dashboard
 
 ---
 

--- a/guhso-backend/app/Http/Controllers/Admin/PostController.php
+++ b/guhso-backend/app/Http/Controllers/Admin/PostController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Post;
+use Illuminate\Http\Request;
+
+class PostController extends Controller
+{
+    /**
+     * Display a listing of the posts.
+     */
+    public function index()
+    {
+        $posts = Post::latest()->paginate(10);
+        return view('dashboard.posts.index', compact('posts'));
+    }
+
+    /**
+     * Show the form for creating a new post.
+     */
+    public function create()
+    {
+        return view('dashboard.posts.create');
+    }
+
+    /**
+     * Store a newly created post in storage.
+     */
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'title' => ['required', 'string', 'max:255'],
+            'body' => ['required', 'string'],
+            'is_featured' => ['sometimes', 'boolean'],
+        ]);
+
+        $data['is_featured'] = $request->has('is_featured');
+
+        Post::create($data);
+
+        return redirect()->route('dashboard.posts')->with('success', 'Post created successfully.');
+    }
+}

--- a/guhso-backend/resources/views/dashboard/layout.blade.php
+++ b/guhso-backend/resources/views/dashboard/layout.blade.php
@@ -41,6 +41,9 @@
                 <a href="{{ route('dashboard.episodes') }}" class="nav-link {{ request()->routeIs('dashboard.episodes') ? 'active' : '' }}">
                     <i class="fas fa-play-circle"></i> Episodes
                 </a>
+                <a href="{{ route('dashboard.posts') }}" class="nav-link {{ request()->routeIs('dashboard.posts*') ? 'active' : '' }}">
+                    <i class="fas fa-blog"></i> Posts
+                </a>
                 <a href="{{ route('dashboard.users') }}" class="nav-link {{ request()->routeIs('dashboard.users') ? 'active' : '' }}">
                     <i class="fas fa-users"></i> Users
                 </a>

--- a/guhso-backend/resources/views/dashboard/posts/create.blade.php
+++ b/guhso-backend/resources/views/dashboard/posts/create.blade.php
@@ -1,0 +1,38 @@
+@extends('dashboard.layout')
+
+@section('title', 'Create Post - Guhso')
+
+@section('content')
+<h1 class="text-2xl font-semibold text-gray-900 mb-6">Create Post</h1>
+
+<form action="{{ route('dashboard.posts.store') }}" method="POST" class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
+    @csrf
+    <div class="mb-4">
+        <label for="title" class="block text-gray-700 text-sm font-bold mb-2">Title</label>
+        <input type="text" name="title" id="title" value="{{ old('title') }}" required class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
+        @error('title')
+            <p class="text-red-500 text-xs italic mt-2">{{ $message }}</p>
+        @enderror
+    </div>
+
+    <div class="mb-4">
+        <label for="body" class="block text-gray-700 text-sm font-bold mb-2">Body</label>
+        <textarea name="body" id="body" rows="5" required class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline">{{ old('body') }}</textarea>
+        @error('body')
+            <p class="text-red-500 text-xs italic mt-2">{{ $message }}</p>
+        @enderror
+    </div>
+
+    <div class="mb-4">
+        <label class="inline-flex items-center">
+            <input type="checkbox" name="is_featured" class="form-checkbox" {{ old('is_featured') ? 'checked' : '' }}>
+            <span class="ml-2">Featured</span>
+        </label>
+    </div>
+
+    <div class="flex items-center justify-end">
+        <a href="{{ route('dashboard.posts') }}" class="mr-4 text-gray-600">Cancel</a>
+        <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded-md">Publish</button>
+    </div>
+</form>
+@endsection

--- a/guhso-backend/resources/views/dashboard/posts/index.blade.php
+++ b/guhso-backend/resources/views/dashboard/posts/index.blade.php
@@ -1,0 +1,42 @@
+@extends('dashboard.layout')
+
+@section('title', 'Posts - Guhso')
+
+@section('content')
+<div class="flex items-center justify-between mb-6">
+    <h1 class="text-2xl font-semibold text-gray-900">Posts</h1>
+    <a href="{{ route('dashboard.posts.create') }}" class="px-4 py-2 bg-blue-600 text-white rounded-md">New Post</a>
+</div>
+
+@if(session('success'))
+    <div class="mb-4 text-green-600">{{ session('success') }}</div>
+@endif
+
+<div class="bg-white shadow overflow-hidden sm:rounded-md">
+    <table class="min-w-full">
+        <thead class="bg-gray-50">
+            <tr>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Title</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Featured</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+            </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200">
+            @forelse($posts as $post)
+            <tr>
+                <td class="px-6 py-4 whitespace-nowrap">{{ $post->title }}</td>
+                <td class="px-6 py-4 whitespace-nowrap">{{ $post->is_featured ? 'Yes' : 'No' }}</td>
+                <td class="px-6 py-4 whitespace-nowrap">{{ $post->created_at->format('Y-m-d') }}</td>
+            </tr>
+            @empty
+            <tr>
+                <td colspan="3" class="px-6 py-4 text-center text-gray-500">No posts found.</td>
+            </tr>
+            @endforelse
+        </tbody>
+    </table>
+    <div class="p-4">
+        {{ $posts->links() }}
+    </div>
+</div>
+@endsection

--- a/guhso-backend/routes/web.php
+++ b/guhso-backend/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\Admin\ShowController;
+use App\Http\Controllers\Admin\PostController;
 use App\Http\Controllers\Auth\LoginController;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Auth;
@@ -85,6 +86,9 @@ Route::middleware('auth')->group(function () {
     Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');
     Route::get('/dashboard/shows', [DashboardController::class, 'shows'])->name('dashboard.shows');
     Route::get('/dashboard/episodes', [DashboardController::class, 'episodes'])->name('dashboard.episodes');
+    Route::get('/dashboard/posts', [PostController::class, 'index'])->name('dashboard.posts');
+    Route::get('/dashboard/posts/create', [PostController::class, 'create'])->name('dashboard.posts.create');
+    Route::post('/dashboard/posts', [PostController::class, 'store'])->name('dashboard.posts.store');
     Route::get('/dashboard/users', [DashboardController::class, 'users'])->name('dashboard.users');
 });
 


### PR DESCRIPTION
## Summary
- add admin PostController for creating posts
- add dashboard views for post list and creation form
- expose post routes and navigation in dashboard

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688e7917a2b083269b4a83521d2c6744