### PR TITLE
fix: position social links below episode details

### DIFF
--- a/guhso-podcast-react/src/pages/EpisodeDetail.css
+++ b/guhso-podcast-react/src/pages/EpisodeDetail.css
@@ -390,13 +390,9 @@
 .episode-social-section {
   display: block;
   width: 100%;
-  margin-bottom: 2rem;
-  margin-top: 3rem;
-  position: relative;
-  top: auto;
-  left: auto;
-  right: auto;
-  bottom: auto;
+  margin: 3rem 0 2rem;
+  position: static;
+  clear: both;
 }
 
 /* Sidebar */


### PR DESCRIPTION
## Summary
- prevent "Share This Episode" section from overlapping description

## Testing
- `npm test -- --watchAll=false` *(fails: IntersectionObserver is not defined)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689188a7a1d88326a041a4baf5003106