### PR TITLE
fix: correct episode detail social layout

### DIFF
--- a/guhso-podcast-react/src/pages/EpisodeDetail.css
+++ b/guhso-podcast-react/src/pages/EpisodeDetail.css
@@ -49,7 +49,6 @@
   overflow-wrap: break-word;
   min-width: 0; /* Allows flex items to shrink below their content size */
   height: auto;
-  min-height: 100%;
   justify-self: start;
   align-self: start;
 }
@@ -364,12 +363,7 @@
 .episode-social {
   border-top: 1px solid rgba(255, 255, 255, 0.1);
   padding-top: 2rem;
-  margin-top: 4rem;
-  margin-bottom: 2rem;
-  position: static;
-  display: block;
-  width: 100%;
-  clear: both;
+  margin: 0;
 }
 
 .episode-social h3 {
@@ -390,13 +384,9 @@
 .episode-social-section {
   display: block;
   width: 100%;
-  margin-bottom: 2rem;
-  margin-top: 3rem;
-  position: relative;
-  top: auto;
-  left: auto;
-  right: auto;
-  bottom: auto;
+  margin: 3rem 0 2rem;
+  position: static;
+  clear: both;
 }
 
 /* Sidebar */
@@ -412,7 +402,7 @@
   scroll-behavior: smooth;
   align-self: start;
   justify-self: start;
-  z-index: 10; /* Higher z-index to ensure it stays above content */
+  z-index: auto;
 }
 
 /* Custom scrollbar for sidebar */

--- a/guhso-podcast-react/src/pages/EpisodeDetail.js
+++ b/guhso-podcast-react/src/pages/EpisodeDetail.js
@@ -229,9 +229,11 @@ const EpisodeDetail = () => {
             <div className="episode-description">
               <h2>About This Episode</h2>
               <div className="description-content">
-                {episode.description.split('\n').map((paragraph, index) => (
-                  <p key={index}>{paragraph}</p>
-                ))}
+                {(episode.description ? episode.description.split('\n') : []).map(
+                  (paragraph, index) => (
+                    <p key={index}>{paragraph}</p>
+                  )
+                )}
               </div>
             </div>
           </section>


### PR DESCRIPTION
## Summary
- guard against missing episode descriptions when rendering paragraphs
- adjust episode social section styles so share links follow content
- drop sidebar z-index to keep social links from overlapping

## Testing
- `npm test -- --watchAll=false` *(fails: IntersectionObserver is not defined)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689188a7a1d88326a041a4baf5003106