### PR TITLE
Remove Featured Card description

### DIFF
--- a/guhso-podcast-react/src/components/Sidebar/FeaturedSection.css
+++ b/guhso-podcast-react/src/components/Sidebar/FeaturedSection.css
@@ -45,18 +45,6 @@
     text-overflow: ellipsis;
 }
 
-.featured-card p {
-    color: var(--text-muted);
-    font-size: 0.9rem;
-    line-height: 1.4;
-    margin: 0;
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
 .featured-nav {
     display: flex;
     justify-content: center;
@@ -119,20 +107,12 @@
     background: rgba(255, 255, 255, 0.05);
 }
 
-.featured-section.loading h3,
-.featured-section.loading p {
+.featured-section.loading h3 {
     background: rgba(255, 255, 255, 0.1);
     border-radius: 4px;
     color: transparent;
-}
-
-.featured-section.loading h3 {
     height: 1.2rem;
     margin-bottom: 0.75rem;
-}
-
-.featured-section.loading p {
-    height: 3rem;
 }
 
 @keyframes shimmer {
@@ -159,9 +139,6 @@
         font-size: 1rem;
     }
     
-    .featured-card p {
-        font-size: 0.85rem;
-    }
 }
 
 /* Dark theme support */
@@ -173,10 +150,6 @@
     
     .featured-card h3 {
         color: #1f2937;
-    }
-    
-    .featured-card p {
-        color: #6b7280;
     }
     
     .featured-nav {

--- a/guhso-podcast-react/src/components/Sidebar/FeaturedSection.js
+++ b/guhso-podcast-react/src/components/Sidebar/FeaturedSection.js
@@ -29,7 +29,6 @@ const FeaturedSection = () => {
         <div className="featured-card">
           <div>
             <h3>{activePost.title}</h3>
-            <p>{activePost.body}</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- drop description paragraph from sidebar's Featured Card
- clean up CSS to remove paragraph styling and adjust loading state

## Testing
- `npm test -- --watchAll=false`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689d443e6d1c8326ad3eb6cdb3630126