### PR TITLE
Remove hero border styling from episode cards

### DIFF
--- a/guhso-podcast-react/src/components/Episodes/EpisodeCard.css
+++ b/guhso-podcast-react/src/components/Episodes/EpisodeCard.css
@@ -244,8 +244,7 @@
 
 /* Hero episode indicator */
 .episode-card.hero {
-    border: 2px solid #ffd700;
-    box-shadow: 0 4px 20px rgba(255, 215, 0, 0.3);
+    /* Removed hero border and glow so featured episodes match regular styling */
 }
 
 .episode-card.hero::before {


### PR DESCRIPTION
## Summary
- Remove hero border styling from episode cards, leaving featured tag without extra border or glow

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689d478b19a48326902297ea52614381