### PR TITLE
Fix Blog loading and error className

### DIFF
--- a/guhso-podcast-react/src/pages/Blog.js
+++ b/guhso-podcast-react/src/pages/Blog.js
@@ -28,7 +28,7 @@ const Blog = () => {
 
   if (loading) {
     return (
-      <div className=".episodes-header">
+      <div className="episodes-header">
         <h1>It Guhso</h1>
         <p>Loading posts...</p>
       </div>
@@ -37,7 +37,7 @@ const Blog = () => {
 
   if (error) {
     return (
-      <div className=".episodes-header">
+      <div className="episodes-header">
         <h1>It Guhso</h1>
         <p className="error-message">Failed to load posts: {error}</p>
       </div>


### PR DESCRIPTION
## Summary
- Remove incorrect dot prefix from Blog page loading and error container className so styles apply

## Testing
- `npm test -- --watchAll=false`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689d6479a0488326af36b8b86088067b