### PR TITLE
Refactor blog layout for responsive container and header

### DIFF
--- a/guhso-podcast-react/src/pages/Blog.css
+++ b/guhso-podcast-react/src/pages/Blog.css
@@ -8,6 +8,10 @@
   margin-bottom: 2rem;
 }
 
+.episodes-header {
+  text-align: center;
+}
+
 .blog-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));

--- a/guhso-podcast-react/src/pages/Blog.js
+++ b/guhso-podcast-react/src/pages/Blog.js
@@ -28,8 +28,10 @@ const Blog = () => {
 
   if (loading) {
     return (
-      <div className=".episodes-header">
-        <h1>It Guhso</h1>
+      <div className="blog-page">
+        <div className="episodes-header">
+          <h1>It Guhso</h1>
+        </div>
         <p>Loading posts...</p>
       </div>
     );
@@ -37,16 +39,20 @@ const Blog = () => {
 
   if (error) {
     return (
-      <div className=".episodes-header">
-        <h1>It Guhso</h1>
+      <div className="blog-page">
+        <div className="episodes-header">
+          <h1>It Guhso</h1>
+        </div>
         <p className="error-message">Failed to load posts: {error}</p>
       </div>
     );
   }
 
   return (
-    <div className="episodes-header">
-      <h1>It Guhso</h1>
+    <div className="blog-page">
+      <div className="episodes-header">
+        <h1>It Guhso</h1>
+      </div>
       <div className="blog-grid">
         {posts.map(post => (
           <PostCard key={post.id} post={post} />


### PR DESCRIPTION
## Summary
- wrap blog content with `.blog-page` container
- move page title into an `episodes-header` block and center it
- add header styling for consistent spacing and alignment

## Testing
- `npm test -- --watchAll=false`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689d6480d150832691e884b83d21ee88