### PR TITLE
fix: use client routing for donate

### DIFF
--- a/guhso-podcast-react/src/components/Layout/Navbar.js
+++ b/guhso-podcast-react/src/components/Layout/Navbar.js
@@ -1,14 +1,15 @@
 // src/components/Layout/Navbar.js
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import './Navbar.css';
 
 const Navbar = () => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const navigate = useNavigate();
 
   const handleBigupClick = () => {
     // Handle registration/donation logic here
-    window.location.href = '/donation';
+    navigate('/donation');
   };
 
   const toggleMobileMenu = () => {


### PR DESCRIPTION
## Summary
- handle Donate button with React Router navigation to avoid full page reloads

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689d6a26b47c832693f7b710f27288ab