### PR TITLE
chore: point frontend to backend API

### DIFF
--- a/guhso-podcast-react/.env
+++ b/guhso-podcast-react/.env
@@ -1,4 +1,4 @@
-REACT_APP_API_URL=https://kjprocleaning.com/api/v1
+REACT_APP_API_URL=https://guhso.com/api/v1
 REACT_APP_APP_NAME=Guhso
 REACT_APP_ENVIRONMENT=production
 

--- a/guhso-podcast-react/.env.example
+++ b/guhso-podcast-react/.env.example
@@ -2,7 +2,7 @@
 # Copy this file to .env and fill in your actual values
 
 # React App Configuration
-REACT_APP_API_URL=https://kjprocleaning.com/api/v1
+REACT_APP_API_URL=https://guhso.com/api/v1
 REACT_APP_APP_NAME=Guhso
 REACT_APP_ENVIRONMENT=production
 

--- a/guhso-podcast-react/src/api.js
+++ b/guhso-podcast-react/src/api.js
@@ -1,4 +1,4 @@
-const API_URL = process.env.REACT_APP_API_URL || 'https://kjprocleaning.com/api/v1';
+const API_URL = process.env.REACT_APP_API_URL || 'https://guhso.com/api/v1';
 
 /**
  * Process episode data to normalize thumbnail fields

--- a/guhso-podcast-react/src/services/emailService.js
+++ b/guhso-podcast-react/src/services/emailService.js
@@ -3,7 +3,7 @@ import { generateDonationConfirmationEmail, generatePlainTextConfirmation } from
 
 class EmailService {
   constructor() {
-    this.apiUrl = process.env.REACT_APP_API_URL || 'https://kjprocleaning.com/api/v1';
+    this.apiUrl = process.env.REACT_APP_API_URL || 'https://guhso.com/api/v1';
   }
 
   /**


### PR DESCRIPTION
## Summary
- use backend API endpoint for React frontend
- sample env files point to live service

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689dce9511bc83268cb47b522c2c7950