### PR TITLE
feat: add swipe and image background to featured card

### DIFF
--- a/guhso-podcast-react/src/components/Sidebar/FeaturedSection.css
+++ b/guhso-podcast-react/src/components/Sidebar/FeaturedSection.css
@@ -17,6 +17,8 @@
 .featured-slider {
     position: relative;
     overflow: hidden;
+    cursor: grab;
+    user-select: none;
 }
 
 .featured-card {
@@ -25,6 +27,9 @@
     border-radius: 12px;
     padding: 1.25rem;
     transition: all 0.3s ease;
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
 }
 
 .featured-card:hover {

--- a/guhso-podcast-react/src/components/Sidebar/FeaturedSection.js
+++ b/guhso-podcast-react/src/components/Sidebar/FeaturedSection.js
@@ -1,11 +1,12 @@
 // src/components/Sidebar/FeaturedSection.js
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { fetchFeaturedPosts } from '../../api';
 import './FeaturedSection.css';
 
 const FeaturedSection = () => {
   const [activeDot, setActiveDot] = useState(0);
   const [featuredItems, setFeaturedItems] = useState([]);
+  const startXRef = useRef(null);
 
   useEffect(() => {
     fetchFeaturedPosts()
@@ -23,10 +24,62 @@ const FeaturedSection = () => {
 
   const activePost = featuredItems[activeDot];
 
+  const handleMouseDown = (e) => {
+    startXRef.current = e.clientX;
+  };
+
+  const handleMouseUp = (e) => {
+    if (startXRef.current === null) return;
+    const diff = e.clientX - startXRef.current;
+    const threshold = 50;
+    if (diff > threshold) {
+      setActiveDot((prev) => (prev - 1 + featuredItems.length) % featuredItems.length);
+    } else if (diff < -threshold) {
+      setActiveDot((prev) => (prev + 1) % featuredItems.length);
+    }
+    startXRef.current = null;
+  };
+
+  const handleTouchStart = (e) => {
+    startXRef.current = e.touches[0].clientX;
+  };
+
+  const handleTouchEnd = (e) => {
+    if (startXRef.current === null) return;
+    const diff = e.changedTouches[0].clientX - startXRef.current;
+    const threshold = 50;
+    if (diff > threshold) {
+      setActiveDot((prev) => (prev - 1 + featuredItems.length) % featuredItems.length);
+    } else if (diff < -threshold) {
+      setActiveDot((prev) => (prev + 1) % featuredItems.length);
+    }
+    startXRef.current = null;
+  };
+
+  const imageUrl =
+    activePost.thumbnail_url ||
+    activePost.hero_thumbnail ||
+    activePost.itunes_image;
+
   return (
     <div className="featured-section">
-      <div className="featured-slider">
-        <div className="featured-card">
+      <div
+        className="featured-slider"
+        onMouseDown={handleMouseDown}
+        onMouseUp={handleMouseUp}
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
+      >
+        <div
+          className="featured-card"
+          style={
+            imageUrl
+              ? {
+                  backgroundImage: `linear-gradient(rgba(0,0,0,0.5), rgba(0,0,0,0.5)), url(${imageUrl})`
+                }
+              : undefined
+          }
+        >
           <div>
             <h3>{activePost.title}</h3>
           </div>


### PR DESCRIPTION
## Summary
- allow mouse/touch swiping on featured card
- show episode thumbnail as featured card background

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689df1eff2e88326b91edf982a70440f