### PR TITLE
feat: add advertisement management

### DIFF
--- a/guhso-backend/app/Http/Controllers/Api/AdvertisementController.php
+++ b/guhso-backend/app/Http/Controllers/Api/AdvertisementController.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Advertisement;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\File;
+
+class AdvertisementController extends Controller
+{
+    /**
+     * Display a listing of advertisements.
+     */
+    public function index(Request $request)
+    {
+        $query = Advertisement::query();
+
+        if ($request->has('status')) {
+            if ($request->status === 'active') {
+                $query->active();
+            } elseif ($request->status === 'inactive') {
+                $now = Carbon::now();
+                $query->where(function ($q) use ($now) {
+                    $q->where('is_active', false)
+                      ->orWhere(function ($q2) use ($now) {
+                          $q2->whereNotNull('start_at')->where('start_at', '>', $now)
+                             ->orWhereNotNull('end_at')->where('end_at', '<', $now);
+                      });
+                });
+            }
+        }
+
+        return response()->json($query->latest()->paginate($request->get('per_page', 10)));
+    }
+
+    /**
+     * Return active advertisements for frontend display.
+     */
+    public function active()
+    {
+        return response()->json(Advertisement::active()->get());
+    }
+
+    /**
+     * Store a newly created advertisement.
+     */
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'image' => 'nullable|image|mimes:jpeg,png,jpg,gif,webp|max:2048',
+            'website_url' => 'nullable|url',
+            'facebook_url' => 'nullable|url',
+            'twitter_url' => 'nullable|url',
+            'instagram_url' => 'nullable|url',
+            'linkedin_url' => 'nullable|url',
+            'phone' => 'nullable|string|max:50',
+            'email' => 'nullable|email',
+            'start_at' => 'nullable|date',
+            'duration_days' => 'nullable|integer|min:1',
+            'end_at' => 'nullable|date',
+            'is_active' => 'boolean',
+        ]);
+
+        $startAt = isset($validated['start_at']) ? Carbon::parse($validated['start_at']) : Carbon::now();
+        $validated['start_at'] = $startAt;
+
+        if (isset($validated['duration_days'])) {
+            $validated['end_at'] = $startAt->copy()->addDays($validated['duration_days']);
+            unset($validated['duration_days']);
+        } elseif (isset($validated['end_at'])) {
+            $validated['end_at'] = Carbon::parse($validated['end_at']);
+        }
+
+        if ($request->hasFile('image')) {
+            $directory = public_path('images/ads');
+            File::ensureDirectoryExists($directory);
+            $image = $request->file('image');
+            $filename = time().'_'.$image->getClientOriginalName();
+            $image->move($directory, $filename);
+            $validated['image'] = 'images/ads/'.$filename;
+        }
+
+        $ad = Advertisement::create($validated);
+
+        return response()->json($ad, 201);
+    }
+
+    /**
+     * Display the specified advertisement.
+     */
+    public function show(Advertisement $ad)
+    {
+        return response()->json($ad);
+    }
+
+    /**
+     * Update the specified advertisement.
+     */
+    public function update(Request $request, Advertisement $ad)
+    {
+        $validated = $request->validate([
+            'title' => 'sometimes|string|max:255',
+            'description' => 'sometimes|nullable|string',
+            'image' => 'sometimes|nullable|image|mimes:jpeg,png,jpg,gif,webp|max:2048',
+            'website_url' => 'sometimes|nullable|url',
+            'facebook_url' => 'sometimes|nullable|url',
+            'twitter_url' => 'sometimes|nullable|url',
+            'instagram_url' => 'sometimes|nullable|url',
+            'linkedin_url' => 'sometimes|nullable|url',
+            'phone' => 'sometimes|nullable|string|max:50',
+            'email' => 'sometimes|nullable|email',
+            'start_at' => 'sometimes|nullable|date',
+            'duration_days' => 'sometimes|nullable|integer|min:1',
+            'end_at' => 'sometimes|nullable|date',
+            'is_active' => 'sometimes|boolean',
+        ]);
+
+        if (isset($validated['start_at'])) {
+            $startAt = Carbon::parse($validated['start_at']);
+            $validated['start_at'] = $startAt;
+        } else {
+            $startAt = $ad->start_at;
+        }
+
+        if (isset($validated['duration_days'])) {
+            $validated['end_at'] = $startAt->copy()->addDays($validated['duration_days']);
+            unset($validated['duration_days']);
+        } elseif (isset($validated['end_at'])) {
+            $validated['end_at'] = Carbon::parse($validated['end_at']);
+        }
+
+        if ($request->hasFile('image')) {
+            if ($ad->image && File::exists(public_path($ad->image))) {
+                File::delete(public_path($ad->image));
+            }
+            $directory = public_path('images/ads');
+            File::ensureDirectoryExists($directory);
+            $image = $request->file('image');
+            $filename = time().'_'.$image->getClientOriginalName();
+            $image->move($directory, $filename);
+            $validated['image'] = 'images/ads/'.$filename;
+        }
+
+        $ad->update($validated);
+
+        return response()->json($ad);
+    }
+
+    /**
+     * Remove the specified advertisement from storage.
+     */
+    public function destroy(Advertisement $ad)
+    {
+        if ($ad->image && File::exists(public_path($ad->image))) {
+            File::delete(public_path($ad->image));
+        }
+        $ad->delete();
+
+        return response()->json(['message' => 'Advertisement deleted successfully']);
+    }
+}

--- a/guhso-backend/app/Models/Advertisement.php
+++ b/guhso-backend/app/Models/Advertisement.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+
+class Advertisement extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'title',
+        'description',
+        'image',
+        'website_url',
+        'facebook_url',
+        'twitter_url',
+        'instagram_url',
+        'linkedin_url',
+        'phone',
+        'email',
+        'start_at',
+        'end_at',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'start_at' => 'datetime',
+        'end_at' => 'datetime',
+        'is_active' => 'boolean',
+    ];
+
+    /**
+     * Scope a query to only include currently active advertisements.
+     */
+    public function scopeActive($query)
+    {
+        $now = Carbon::now();
+        return $query->where('is_active', true)
+                     ->where(function ($q) use ($now) {
+                         $q->whereNull('start_at')->orWhere('start_at', '<=', $now);
+                     })
+                     ->where(function ($q) use ($now) {
+                         $q->whereNull('end_at')->orWhere('end_at', '>=', $now);
+                     });
+    }
+}

--- a/guhso-backend/database/factories/AdvertisementFactory.php
+++ b/guhso-backend/database/factories/AdvertisementFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Advertisement;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class AdvertisementFactory extends Factory
+{
+    protected $model = Advertisement::class;
+
+    public function definition(): array
+    {
+        return [
+            'title' => $this->faker->sentence,
+            'description' => $this->faker->paragraph,
+            'website_url' => $this->faker->url,
+            'facebook_url' => $this->faker->url,
+            'twitter_url' => $this->faker->url,
+            'instagram_url' => $this->faker->url,
+            'linkedin_url' => $this->faker->url,
+            'phone' => $this->faker->phoneNumber,
+            'email' => $this->faker->safeEmail,
+            'start_at' => now()->subDay(),
+            'end_at' => now()->addDay(),
+            'is_active' => true,
+        ];
+    }
+}

--- a/guhso-backend/database/migrations/2025_08_06_000000_create_advertisements_table.php
+++ b/guhso-backend/database/migrations/2025_08_06_000000_create_advertisements_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('advertisements', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->string('image')->nullable();
+            $table->string('website_url')->nullable();
+            $table->string('facebook_url')->nullable();
+            $table->string('twitter_url')->nullable();
+            $table->string('instagram_url')->nullable();
+            $table->string('linkedin_url')->nullable();
+            $table->string('phone')->nullable();
+            $table->string('email')->nullable();
+            $table->dateTime('start_at')->nullable();
+            $table->dateTime('end_at')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('advertisements');
+    }
+};

--- a/guhso-backend/routes/api.php
+++ b/guhso-backend/routes/api.php
@@ -7,7 +7,8 @@ use App\Http\Controllers\Api\EpisodeController as ApiEpisodeController;
 use App\Http\Controllers\Api\FavoriteController;
 use App\Http\Controllers\Api\CommentController;
 use App\Http\Controllers\Api\PostController;
-use App\Http\Controllers\SearchController; 
+use App\Http\Controllers\Api\AdvertisementController;
+use App\Http\Controllers\SearchController;
 use Illuminate\Support\Facades\Route;
 
 Route::prefix('v1')->group(function () {
@@ -39,6 +40,9 @@ Route::prefix('v1')->group(function () {
     Route::get('/categories', function() {
         return \App\Models\Category::withCount('shows')->get();
     });
+
+    // Advertisements
+    Route::get('/ads', [AdvertisementController::class, 'active']);
     
     // Authentication endpoints
     Route::post('/register', [AuthController::class, 'register']);
@@ -74,6 +78,7 @@ Route::prefix('v1')->group(function () {
     Route::middleware(['auth:sanctum', 'admin'])->prefix('admin')->group(function () {
         Route::apiResource('shows', \App\Http\Controllers\Admin\ShowController::class);
         Route::apiResource('posts', PostController::class);
+        Route::apiResource('ads', AdvertisementController::class);
         Route::get('/dashboard/stats', function() {
             return response()->json([
                 'total_shows' => \App\Models\Show::count(),

--- a/guhso-backend/tests/Feature/AdvertisementControllerTest.php
+++ b/guhso-backend/tests/Feature/AdvertisementControllerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Advertisement;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class AdvertisementControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_store_calculates_end_at_from_duration(): void
+    {
+        Sanctum::actingAs(User::factory()->create(['role' => 'admin']));
+
+        $response = $this->postJson('/api/v1/admin/ads', [
+            'title' => 'Test Ad',
+            'duration_days' => 5,
+            'start_at' => '2025-01-01 08:00:00',
+        ]);
+
+        $response->assertStatus(201)->assertJsonFragment(['title' => 'Test Ad']);
+
+        $ad = Advertisement::first();
+        $this->assertEquals('2025-01-01 08:00:00', $ad->start_at->format('Y-m-d H:i:s'));
+        $this->assertEquals('2025-01-06 08:00:00', $ad->end_at->format('Y-m-d H:i:s'));
+    }
+
+    public function test_active_endpoint_returns_only_current_ads(): void
+    {
+        Advertisement::factory()->create([
+            'title' => 'Active Ad',
+            'start_at' => now()->subDay(),
+            'end_at' => now()->addDay(),
+            'is_active' => true,
+        ]);
+
+        Advertisement::factory()->create([
+            'title' => 'Expired Ad',
+            'start_at' => now()->subDays(5),
+            'end_at' => now()->subDay(),
+            'is_active' => true,
+        ]);
+
+        $response = $this->getJson('/api/v1/ads');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(1);
+        $response->assertJsonFragment(['title' => 'Active Ad']);
+    }
+}


### PR DESCRIPTION
## Summary
- create advertisements table and model with social links and activation windows
- expose admin CRUD and public ad listing endpoints
- add factory and feature tests for ad duration and active filtering

## Testing
- `DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: GitHub API requires auth token)*

------
https://chatgpt.com/codex/tasks/task_e_689df6a808d88326886e68fa377bed24