### PR TITLE
feat: add advertisement management

### DIFF
--- a/guhso-backend/app/Http/Controllers/Admin/AdvertisementController.php
+++ b/guhso-backend/app/Http/Controllers/Admin/AdvertisementController.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Advertisement;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\File;
+
+class AdvertisementController extends Controller
+{
+    /**
+     * Display a listing of the advertisements.
+     */
+    public function index()
+    {
+        $ads = Advertisement::latest()->paginate(10);
+        return view('dashboard.advertisements.index', compact('ads'));
+    }
+
+    /**
+     * Show the form for creating a new advertisement.
+     */
+    public function create()
+    {
+        return view('dashboard.advertisements.create');
+    }
+
+    /**
+     * Store a newly created advertisement in storage.
+     */
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'image' => 'nullable|image|mimes:jpeg,png,jpg,gif,webp|max:2048',
+            'website_url' => 'nullable|url',
+            'facebook_url' => 'nullable|url',
+            'twitter_url' => 'nullable|url',
+            'instagram_url' => 'nullable|url',
+            'linkedin_url' => 'nullable|url',
+            'phone' => 'nullable|string|max:50',
+            'email' => 'nullable|email',
+            'start_at' => 'nullable|date',
+            'duration_days' => 'nullable|integer|min:1',
+            'end_at' => 'nullable|date',
+            'is_active' => 'sometimes|boolean',
+        ]);
+
+        $startAt = isset($validated['start_at']) ? Carbon::parse($validated['start_at']) : Carbon::now();
+        $validated['start_at'] = $startAt;
+
+        if (isset($validated['duration_days'])) {
+            $validated['end_at'] = $startAt->copy()->addDays($validated['duration_days']);
+            unset($validated['duration_days']);
+        } elseif (isset($validated['end_at'])) {
+            $validated['end_at'] = Carbon::parse($validated['end_at']);
+        }
+
+        if ($request->hasFile('image')) {
+            $directory = public_path('images/ads');
+            File::ensureDirectoryExists($directory);
+            $image = $request->file('image');
+            $filename = time().'_'.$image->getClientOriginalName();
+            $image->move($directory, $filename);
+            $validated['image'] = 'images/ads/'.$filename;
+        }
+
+        $validated['is_active'] = $request->has('is_active');
+
+        Advertisement::create($validated);
+
+        return redirect()->route('dashboard.ads')->with('success', 'Advertisement created successfully.');
+    }
+
+    /**
+     * Show the form for editing the specified advertisement.
+     */
+    public function edit(Advertisement $ad)
+    {
+        return view('dashboard.advertisements.edit', compact('ad'));
+    }
+
+    /**
+     * Update the specified advertisement in storage.
+     */
+    public function update(Request $request, Advertisement $ad)
+    {
+        $validated = $request->validate([
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'image' => 'nullable|image|mimes:jpeg,png,jpg,gif,webp|max:2048',
+            'website_url' => 'nullable|url',
+            'facebook_url' => 'nullable|url',
+            'twitter_url' => 'nullable|url',
+            'instagram_url' => 'nullable|url',
+            'linkedin_url' => 'nullable|url',
+            'phone' => 'nullable|string|max:50',
+            'email' => 'nullable|email',
+            'start_at' => 'nullable|date',
+            'duration_days' => 'nullable|integer|min:1',
+            'end_at' => 'nullable|date',
+            'is_active' => 'sometimes|boolean',
+        ]);
+
+        if (isset($validated['start_at'])) {
+            $startAt = Carbon::parse($validated['start_at']);
+            $validated['start_at'] = $startAt;
+        } else {
+            $startAt = $ad->start_at;
+        }
+
+        if (isset($validated['duration_days'])) {
+            $validated['end_at'] = $startAt->copy()->addDays($validated['duration_days']);
+            unset($validated['duration_days']);
+        } elseif (isset($validated['end_at'])) {
+            $validated['end_at'] = Carbon::parse($validated['end_at']);
+        }
+
+        if ($request->hasFile('image')) {
+            if ($ad->image && File::exists(public_path($ad->image))) {
+                File::delete(public_path($ad->image));
+            }
+            $directory = public_path('images/ads');
+            File::ensureDirectoryExists($directory);
+            $image = $request->file('image');
+            $filename = time().'_'.$image->getClientOriginalName();
+            $image->move($directory, $filename);
+            $validated['image'] = 'images/ads/'.$filename;
+        }
+
+        $validated['is_active'] = $request->has('is_active');
+
+        $ad->update($validated);
+
+        return redirect()->route('dashboard.ads')->with('success', 'Advertisement updated successfully.');
+    }
+
+    /**
+     * Remove the specified advertisement from storage.
+     */
+    public function destroy(Advertisement $ad)
+    {
+        if ($ad->image && File::exists(public_path($ad->image))) {
+            File::delete(public_path($ad->image));
+        }
+        $ad->delete();
+
+        return redirect()->route('dashboard.ads')->with('success', 'Advertisement deleted successfully.');
+    }
+}

--- a/guhso-backend/app/Http/Controllers/Api/AdvertisementController.php
+++ b/guhso-backend/app/Http/Controllers/Api/AdvertisementController.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Advertisement;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\File;
+
+class AdvertisementController extends Controller
+{
+    /**
+     * Display a listing of advertisements.
+     */
+    public function index(Request $request)
+    {
+        $query = Advertisement::query();
+
+        if ($request->has('status')) {
+            if ($request->status === 'active') {
+                $query->active();
+            } elseif ($request->status === 'inactive') {
+                $now = Carbon::now();
+                $query->where(function ($q) use ($now) {
+                    $q->where('is_active', false)
+                      ->orWhere(function ($q2) use ($now) {
+                          $q2->whereNotNull('start_at')->where('start_at', '>', $now)
+                             ->orWhereNotNull('end_at')->where('end_at', '<', $now);
+                      });
+                });
+            }
+        }
+
+        return response()->json($query->latest()->paginate($request->get('per_page', 10)));
+    }
+
+    /**
+     * Return active advertisements for frontend display.
+     */
+    public function active()
+    {
+        return response()->json(Advertisement::active()->get());
+    }
+
+    /**
+     * Store a newly created advertisement.
+     */
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'image' => 'nullable|image|mimes:jpeg,png,jpg,gif,webp|max:2048',
+            'website_url' => 'nullable|url',
+            'facebook_url' => 'nullable|url',
+            'twitter_url' => 'nullable|url',
+            'instagram_url' => 'nullable|url',
+            'linkedin_url' => 'nullable|url',
+            'phone' => 'nullable|string|max:50',
+            'email' => 'nullable|email',
+            'start_at' => 'nullable|date',
+            'duration_days' => 'nullable|integer|min:1',
+            'end_at' => 'nullable|date',
+            'is_active' => 'boolean',
+        ]);
+
+        $startAt = isset($validated['start_at']) ? Carbon::parse($validated['start_at']) : Carbon::now();
+        $validated['start_at'] = $startAt;
+
+        if (isset($validated['duration_days'])) {
+            $validated['end_at'] = $startAt->copy()->addDays($validated['duration_days']);
+            unset($validated['duration_days']);
+        } elseif (isset($validated['end_at'])) {
+            $validated['end_at'] = Carbon::parse($validated['end_at']);
+        }
+
+        if ($request->hasFile('image')) {
+            $directory = public_path('images/ads');
+            File::ensureDirectoryExists($directory);
+            $image = $request->file('image');
+            $filename = time().'_'.$image->getClientOriginalName();
+            $image->move($directory, $filename);
+            $validated['image'] = 'images/ads/'.$filename;
+        }
+
+        $ad = Advertisement::create($validated);
+
+        return response()->json($ad, 201);
+    }
+
+    /**
+     * Display the specified advertisement.
+     */
+    public function show(Advertisement $ad)
+    {
+        return response()->json($ad);
+    }
+
+    /**
+     * Update the specified advertisement.
+     */
+    public function update(Request $request, Advertisement $ad)
+    {
+        $validated = $request->validate([
+            'title' => 'sometimes|string|max:255',
+            'description' => 'sometimes|nullable|string',
+            'image' => 'sometimes|nullable|image|mimes:jpeg,png,jpg,gif,webp|max:2048',
+            'website_url' => 'sometimes|nullable|url',
+            'facebook_url' => 'sometimes|nullable|url',
+            'twitter_url' => 'sometimes|nullable|url',
+            'instagram_url' => 'sometimes|nullable|url',
+            'linkedin_url' => 'sometimes|nullable|url',
+            'phone' => 'sometimes|nullable|string|max:50',
+            'email' => 'sometimes|nullable|email',
+            'start_at' => 'sometimes|nullable|date',
+            'duration_days' => 'sometimes|nullable|integer|min:1',
+            'end_at' => 'sometimes|nullable|date',
+            'is_active' => 'sometimes|boolean',
+        ]);
+
+        if (isset($validated['start_at'])) {
+            $startAt = Carbon::parse($validated['start_at']);
+            $validated['start_at'] = $startAt;
+        } else {
+            $startAt = $ad->start_at;
+        }
+
+        if (isset($validated['duration_days'])) {
+            $validated['end_at'] = $startAt->copy()->addDays($validated['duration_days']);
+            unset($validated['duration_days']);
+        } elseif (isset($validated['end_at'])) {
+            $validated['end_at'] = Carbon::parse($validated['end_at']);
+        }
+
+        if ($request->hasFile('image')) {
+            if ($ad->image && File::exists(public_path($ad->image))) {
+                File::delete(public_path($ad->image));
+            }
+            $directory = public_path('images/ads');
+            File::ensureDirectoryExists($directory);
+            $image = $request->file('image');
+            $filename = time().'_'.$image->getClientOriginalName();
+            $image->move($directory, $filename);
+            $validated['image'] = 'images/ads/'.$filename;
+        }
+
+        $ad->update($validated);
+
+        return response()->json($ad);
+    }
+
+    /**
+     * Remove the specified advertisement from storage.
+     */
+    public function destroy(Advertisement $ad)
+    {
+        if ($ad->image && File::exists(public_path($ad->image))) {
+            File::delete(public_path($ad->image));
+        }
+        $ad->delete();
+
+        return response()->json(['message' => 'Advertisement deleted successfully']);
+    }
+}

--- a/guhso-backend/app/Models/Advertisement.php
+++ b/guhso-backend/app/Models/Advertisement.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+
+class Advertisement extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'title',
+        'description',
+        'image',
+        'website_url',
+        'facebook_url',
+        'twitter_url',
+        'instagram_url',
+        'linkedin_url',
+        'phone',
+        'email',
+        'start_at',
+        'end_at',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'start_at' => 'datetime',
+        'end_at' => 'datetime',
+        'is_active' => 'boolean',
+    ];
+
+    /**
+     * Scope a query to only include currently active advertisements.
+     */
+    public function scopeActive($query)
+    {
+        $now = Carbon::now();
+        return $query->where('is_active', true)
+                     ->where(function ($q) use ($now) {
+                         $q->whereNull('start_at')->orWhere('start_at', '<=', $now);
+                     })
+                     ->where(function ($q) use ($now) {
+                         $q->whereNull('end_at')->orWhere('end_at', '>=', $now);
+                     });
+    }
+}

--- a/guhso-backend/database/factories/AdvertisementFactory.php
+++ b/guhso-backend/database/factories/AdvertisementFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Advertisement;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class AdvertisementFactory extends Factory
+{
+    protected $model = Advertisement::class;
+
+    public function definition(): array
+    {
+        return [
+            'title' => $this->faker->sentence,
+            'description' => $this->faker->paragraph,
+            'website_url' => $this->faker->url,
+            'facebook_url' => $this->faker->url,
+            'twitter_url' => $this->faker->url,
+            'instagram_url' => $this->faker->url,
+            'linkedin_url' => $this->faker->url,
+            'phone' => $this->faker->phoneNumber,
+            'email' => $this->faker->safeEmail,
+            'start_at' => now()->subDay(),
+            'end_at' => now()->addDay(),
+            'is_active' => true,
+        ];
+    }
+}

--- a/guhso-backend/database/migrations/2025_08_06_000000_create_advertisements_table.php
+++ b/guhso-backend/database/migrations/2025_08_06_000000_create_advertisements_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('advertisements', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->string('image')->nullable();
+            $table->string('website_url')->nullable();
+            $table->string('facebook_url')->nullable();
+            $table->string('twitter_url')->nullable();
+            $table->string('instagram_url')->nullable();
+            $table->string('linkedin_url')->nullable();
+            $table->string('phone')->nullable();
+            $table->string('email')->nullable();
+            $table->dateTime('start_at')->nullable();
+            $table->dateTime('end_at')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('advertisements');
+    }
+};

--- a/guhso-backend/resources/views/dashboard/advertisements/create.blade.php
+++ b/guhso-backend/resources/views/dashboard/advertisements/create.blade.php
@@ -1,0 +1,85 @@
+@extends('dashboard.layout')
+
+@section('title', 'Create Advertisement - Guhso')
+
+@section('content')
+<div class="flex items-center justify-between mb-6">
+    <h1 class="text-2xl font-semibold text-gray-900">Create Advertisement</h1>
+    <a href="{{ route('dashboard.ads') }}" class="text-gray-600 hover:text-gray-900">&larr; Back to Ads</a>
+</div>
+
+<form action="{{ route('dashboard.ads.store') }}" method="POST" enctype="multipart/form-data" class="bg-white shadow-md rounded-lg p-6">
+    @csrf
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div>
+            <label for="title" class="block text-sm font-medium text-gray-700 mb-2">Title *</label>
+            <input type="text" name="title" id="title" value="{{ old('title') }}" required class="w-full border border-gray-300 rounded-md px-3 py-2">
+            @error('title')<p class="text-red-500 text-sm mt-1">{{ $message }}</p>@enderror
+        </div>
+        <div>
+            <label for="image" class="block text-sm font-medium text-gray-700 mb-2">Image</label>
+            <input type="file" name="image" id="image" class="w-full text-sm text-gray-500">
+            @error('image')<p class="text-red-500 text-sm mt-1">{{ $message }}</p>@enderror
+        </div>
+        <div class="md:col-span-2">
+            <label for="description" class="block text-sm font-medium text-gray-700 mb-2">Description</label>
+            <textarea name="description" id="description" rows="4" class="w-full border border-gray-300 rounded-md px-3 py-2">{{ old('description') }}</textarea>
+            @error('description')<p class="text-red-500 text-sm mt-1">{{ $message }}</p>@enderror
+        </div>
+        <div>
+            <label for="website_url" class="block text-sm font-medium text-gray-700 mb-2">Website URL</label>
+            <input type="url" name="website_url" id="website_url" value="{{ old('website_url') }}" class="w-full border border-gray-300 rounded-md px-3 py-2">
+            @error('website_url')<p class="text-red-500 text-sm mt-1">{{ $message }}</p>@enderror
+        </div>
+        <div>
+            <label for="facebook_url" class="block text-sm font-medium text-gray-700 mb-2">Facebook URL</label>
+            <input type="url" name="facebook_url" id="facebook_url" value="{{ old('facebook_url') }}" class="w-full border border-gray-300 rounded-md px-3 py-2">
+            @error('facebook_url')<p class="text-red-500 text-sm mt-1">{{ $message }}</p>@enderror
+        </div>
+        <div>
+            <label for="twitter_url" class="block text-sm font-medium text-gray-700 mb-2">Twitter URL</label>
+            <input type="url" name="twitter_url" id="twitter_url" value="{{ old('twitter_url') }}" class="w-full border border-gray-300 rounded-md px-3 py-2">
+            @error('twitter_url')<p class="text-red-500 text-sm mt-1">{{ $message }}</p>@enderror
+        </div>
+        <div>
+            <label for="instagram_url" class="block text-sm font-medium text-gray-700 mb-2">Instagram URL</label>
+            <input type="url" name="instagram_url" id="instagram_url" value="{{ old('instagram_url') }}" class="w-full border border-gray-300 rounded-md px-3 py-2">
+            @error('instagram_url')<p class="text-red-500 text-sm mt-1">{{ $message }}</p>@enderror
+        </div>
+        <div>
+            <label for="linkedin_url" class="block text-sm font-medium text-gray-700 mb-2">LinkedIn URL</label>
+            <input type="url" name="linkedin_url" id="linkedin_url" value="{{ old('linkedin_url') }}" class="w-full border border-gray-300 rounded-md px-3 py-2">
+            @error('linkedin_url')<p class="text-red-500 text-sm mt-1">{{ $message }}</p>@enderror
+        </div>
+        <div>
+            <label for="phone" class="block text-sm font-medium text-gray-700 mb-2">Phone</label>
+            <input type="text" name="phone" id="phone" value="{{ old('phone') }}" class="w-full border border-gray-300 rounded-md px-3 py-2">
+            @error('phone')<p class="text-red-500 text-sm mt-1">{{ $message }}</p>@enderror
+        </div>
+        <div>
+            <label for="email" class="block text-sm font-medium text-gray-700 mb-2">Email</label>
+            <input type="email" name="email" id="email" value="{{ old('email') }}" class="w-full border border-gray-300 rounded-md px-3 py-2">
+            @error('email')<p class="text-red-500 text-sm mt-1">{{ $message }}</p>@enderror
+        </div>
+        <div>
+            <label for="start_at" class="block text-sm font-medium text-gray-700 mb-2">Start At</label>
+            <input type="datetime-local" name="start_at" id="start_at" value="{{ old('start_at') }}" class="w-full border border-gray-300 rounded-md px-3 py-2">
+            @error('start_at')<p class="text-red-500 text-sm mt-1">{{ $message }}</p>@enderror
+        </div>
+        <div>
+            <label for="duration_days" class="block text-sm font-medium text-gray-700 mb-2">Duration (days)</label>
+            <input type="number" name="duration_days" id="duration_days" value="{{ old('duration_days') }}" class="w-full border border-gray-300 rounded-md px-3 py-2">
+            @error('duration_days')<p class="text-red-500 text-sm mt-1">{{ $message }}</p>@enderror
+        </div>
+        <div class="flex items-center">
+            <input type="checkbox" name="is_active" id="is_active" class="rounded border-gray-300 text-blue-600" {{ old('is_active') ? 'checked' : '' }}>
+            <label for="is_active" class="ml-2 text-sm text-gray-700">Active</label>
+        </div>
+    </div>
+
+    <div class="flex items-center justify-end mt-6">
+        <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700">Save Advertisement</button>
+    </div>
+</form>
+@endsection

--- a/guhso-backend/resources/views/dashboard/advertisements/edit.blade.php
+++ b/guhso-backend/resources/views/dashboard/advertisements/edit.blade.php
@@ -1,0 +1,94 @@
+@extends('dashboard.layout')
+
+@section('title', 'Edit Advertisement - Guhso')
+
+@section('content')
+<div class="flex items-center justify-between mb-6">
+    <h1 class="text-2xl font-semibold text-gray-900">Edit Advertisement</h1>
+    <a href="{{ route('dashboard.ads') }}" class="text-gray-600 hover:text-gray-900">&larr; Back to Ads</a>
+</div>
+
+<form action="{{ route('dashboard.ads.update', $ad) }}" method="POST" enctype="multipart/form-data" class="bg-white shadow-md rounded-lg p-6">
+    @csrf
+    @method('PUT')
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div>
+            <label for="title" class="block text-sm font-medium text-gray-700 mb-2">Title *</label>
+            <input type="text" name="title" id="title" value="{{ old('title', $ad->title) }}" required class="w-full border border-gray-300 rounded-md px-3 py-2">
+            @error('title')<p class="text-red-500 text-sm mt-1">{{ $message }}</p>@enderror
+        </div>
+        <div>
+            <label for="image" class="block text-sm font-medium text-gray-700 mb-2">Image</label>
+            @if($ad->image)
+                <img src="{{ asset($ad->image) }}" alt="Image" class="w-24 h-24 object-cover mb-2">
+            @endif
+            <input type="file" name="image" id="image" class="w-full text-sm text-gray-500">
+            @error('image')<p class="text-red-500 text-sm mt-1">{{ $message }}</p>@enderror
+        </div>
+        <div class="md:col-span-2">
+            <label for="description" class="block text-sm font-medium text-gray-700 mb-2">Description</label>
+            <textarea name="description" id="description" rows="4" class="w-full border border-gray-300 rounded-md px-3 py-2">{{ old('description', $ad->description) }}</textarea>
+            @error('description')<p class="text-red-500 text-sm mt-1">{{ $message }}</p>@enderror
+        </div>
+        <div>
+            <label for="website_url" class="block text-sm font-medium text-gray-700 mb-2">Website URL</label>
+            <input type="url" name="website_url" id="website_url" value="{{ old('website_url', $ad->website_url) }}" class="w-full border border-gray-300 rounded-md px-3 py-2">
+            @error('website_url')<p class="text-red-500 text-sm mt-1">{{ $message }}</p>@enderror
+        </div>
+        <div>
+            <label for="facebook_url" class="block text-sm font-medium text-gray-700 mb-2">Facebook URL</label>
+            <input type="url" name="facebook_url" id="facebook_url" value="{{ old('facebook_url', $ad->facebook_url) }}" class="w-full border border-gray-300 rounded-md px-3 py-2">
+            @error('facebook_url')<p class="text-red-500 text-sm mt-1">{{ $message }}</p>@enderror
+        </div>
+        <div>
+            <label for="twitter_url" class="block text-sm font-medium text-gray-700 mb-2">Twitter URL</label>
+            <input type="url" name="twitter_url" id="twitter_url" value="{{ old('twitter_url', $ad->twitter_url) }}" class="w-full border border-gray-300 rounded-md px-3 py-2">
+            @error('twitter_url')<p class="text-red-500 text-sm mt-1">{{ $message }}</p>@enderror
+        </div>
+        <div>
+            <label for="instagram_url" class="block text-sm font-medium text-gray-700 mb-2">Instagram URL</label>
+            <input type="url" name="instagram_url" id="instagram_url" value="{{ old('instagram_url', $ad->instagram_url) }}" class="w-full border border-gray-300 rounded-md px-3 py-2">
+            @error('instagram_url')<p class="text-red-500 text-sm mt-1">{{ $message }}</p>@enderror
+        </div>
+        <div>
+            <label for="linkedin_url" class="block text-sm font-medium text-gray-700 mb-2">LinkedIn URL</label>
+            <input type="url" name="linkedin_url" id="linkedin_url" value="{{ old('linkedin_url', $ad->linkedin_url) }}" class="w-full border border-gray-300 rounded-md px-3 py-2">
+            @error('linkedin_url')<p class="text-red-500 text-sm mt-1">{{ $message }}</p>@enderror
+        </div>
+        <div>
+            <label for="phone" class="block text-sm font-medium text-gray-700 mb-2">Phone</label>
+            <input type="text" name="phone" id="phone" value="{{ old('phone', $ad->phone) }}" class="w-full border border-gray-300 rounded-md px-3 py-2">
+            @error('phone')<p class="text-red-500 text-sm mt-1">{{ $message }}</p>@enderror
+        </div>
+        <div>
+            <label for="email" class="block text-sm font-medium text-gray-700 mb-2">Email</label>
+            <input type="email" name="email" id="email" value="{{ old('email', $ad->email) }}" class="w-full border border-gray-300 rounded-md px-3 py-2">
+            @error('email')<p class="text-red-500 text-sm mt-1">{{ $message }}</p>@enderror
+        </div>
+        <div>
+            <label for="start_at" class="block text-sm font-medium text-gray-700 mb-2">Start At</label>
+            <input type="datetime-local" name="start_at" id="start_at" value="{{ old('start_at', optional($ad->start_at)->format('Y-m-d\TH:i')) }}" class="w-full border border-gray-300 rounded-md px-3 py-2">
+            @error('start_at')<p class="text-red-500 text-sm mt-1">{{ $message }}</p>@enderror
+        </div>
+        <div>
+            <label for="duration_days" class="block text-sm font-medium text-gray-700 mb-2">Duration (days)</label>
+            <input type="number" name="duration_days" id="duration_days" class="w-full border border-gray-300 rounded-md px-3 py-2">
+            @error('duration_days')<p class="text-red-500 text-sm mt-1">{{ $message }}</p>@enderror
+        </div>
+        <div>
+            <label for="end_at" class="block text-sm font-medium text-gray-700 mb-2">End At</label>
+            <input type="datetime-local" name="end_at" id="end_at" value="{{ old('end_at', optional($ad->end_at)->format('Y-m-d\TH:i')) }}" class="w-full border border-gray-300 rounded-md px-3 py-2">
+            @error('end_at')<p class="text-red-500 text-sm mt-1">{{ $message }}</p>@enderror
+        </div>
+        <div class="flex items-center">
+            <input type="checkbox" name="is_active" id="is_active" class="rounded border-gray-300 text-blue-600" {{ old('is_active', $ad->is_active) ? 'checked' : '' }}>
+            <label for="is_active" class="ml-2 text-sm text-gray-700">Active</label>
+        </div>
+    </div>
+
+    <div class="flex items-center justify-end mt-6">
+        <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700">Update Advertisement</button>
+    </div>
+</form>
+@endsection

--- a/guhso-backend/resources/views/dashboard/advertisements/index.blade.php
+++ b/guhso-backend/resources/views/dashboard/advertisements/index.blade.php
@@ -1,0 +1,68 @@
+@extends('dashboard.layout')
+
+@section('title', 'Advertisements - Guhso')
+
+@section('content')
+<div class="flex items-center justify-between mb-6">
+    <h1 class="text-2xl font-semibold text-gray-900">Advertisements</h1>
+    <a href="{{ route('dashboard.ads.create') }}" class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700">New Ad</a>
+</div>
+
+@if(session('success'))
+    <div class="mb-4 p-4 bg-green-100 border border-green-400 text-green-700 rounded">{{ session('success') }}</div>
+@endif
+
+<div class="bg-white shadow overflow-hidden sm:rounded-md">
+    <table class="min-w-full">
+        <thead class="bg-gray-50">
+            <tr>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Title</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Start</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">End</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+            </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200">
+            @forelse($ads as $ad)
+            <tr class="hover:bg-gray-50">
+                <td class="px-6 py-4">
+                    <div class="flex items-center">
+                        @if($ad->image)
+                            <img src="{{ asset($ad->image) }}" alt="Image" class="w-12 h-12 object-cover rounded mr-3">
+                        @endif
+                        <div class="text-sm font-medium text-gray-900">{{ $ad->title }}</div>
+                    </div>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    @if($ad->is_active)
+                        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">Active</span>
+                    @else
+                        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">Inactive</span>
+                    @endif
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ $ad->start_at ? $ad->start_at->format('M j, Y') : '-' }}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ $ad->end_at ? $ad->end_at->format('M j, Y') : '-' }}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                    <div class="flex space-x-2">
+                        <a href="{{ route('dashboard.ads.edit', $ad) }}" class="text-blue-600 hover:text-blue-900">Edit</a>
+                        <form action="{{ route('dashboard.ads.destroy', $ad) }}" method="POST" class="inline" onsubmit="return confirm('Are you sure?')">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="text-red-600 hover:text-red-900">Delete</button>
+                        </form>
+                    </div>
+                </td>
+            </tr>
+            @empty
+            <tr>
+                <td colspan="5" class="px-6 py-4 text-center text-gray-500">No advertisements found.</td>
+            </tr>
+            @endforelse
+        </tbody>
+    </table>
+    <div class="p-4">
+        {{ $ads->links() }}
+    </div>
+</div>
+@endsection

--- a/guhso-backend/resources/views/dashboard/layout.blade.php
+++ b/guhso-backend/resources/views/dashboard/layout.blade.php
@@ -67,6 +67,10 @@
                             <i class="fas fa-blog nav-icon" style="margin-right: 16px;"></i>
                             <span>Posts</span>
                         </a>
+                        <a href="{{ route('dashboard.ads') }}" class="nav-link {{ request()->routeIs('dashboard.ads*') ? 'active' : '' }}">
+                            <i class="fas fa-bullhorn nav-icon" style="margin-right: 16px;"></i>
+                            <span>Advertisements</span>
+                        </a>
                         <a href="{{ route('dashboard.users') }}" class="nav-link {{ request()->routeIs('dashboard.users') ? 'active' : '' }}">
                             <i class="fas fa-users nav-icon" style="margin-right: 16px;"></i>
                             <span>Users</span>

--- a/guhso-backend/routes/api.php
+++ b/guhso-backend/routes/api.php
@@ -7,7 +7,8 @@ use App\Http\Controllers\Api\EpisodeController as ApiEpisodeController;
 use App\Http\Controllers\Api\FavoriteController;
 use App\Http\Controllers\Api\CommentController;
 use App\Http\Controllers\Api\PostController;
-use App\Http\Controllers\SearchController; 
+use App\Http\Controllers\Api\AdvertisementController;
+use App\Http\Controllers\SearchController;
 use Illuminate\Support\Facades\Route;
 
 Route::prefix('v1')->group(function () {
@@ -39,6 +40,9 @@ Route::prefix('v1')->group(function () {
     Route::get('/categories', function() {
         return \App\Models\Category::withCount('shows')->get();
     });
+
+    // Advertisements
+    Route::get('/ads', [AdvertisementController::class, 'active']);
     
     // Authentication endpoints
     Route::post('/register', [AuthController::class, 'register']);
@@ -74,6 +78,7 @@ Route::prefix('v1')->group(function () {
     Route::middleware(['auth:sanctum', 'admin'])->prefix('admin')->group(function () {
         Route::apiResource('shows', \App\Http\Controllers\Admin\ShowController::class);
         Route::apiResource('posts', PostController::class);
+        Route::apiResource('ads', AdvertisementController::class);
         Route::get('/dashboard/stats', function() {
             return response()->json([
                 'total_shows' => \App\Models\Show::count(),

--- a/guhso-backend/routes/web.php
+++ b/guhso-backend/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\Admin\ShowController;
 use App\Http\Controllers\Admin\PostController;
+use App\Http\Controllers\Admin\AdvertisementController;
 use App\Http\Controllers\Auth\LoginController;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Auth;
@@ -100,6 +101,13 @@ Route::middleware('auth')->group(function () {
     Route::get('/dashboard/posts/{post}/edit', [PostController::class, 'edit'])->name('dashboard.posts.edit');
     Route::put('/dashboard/posts/{post}', [PostController::class, 'update'])->name('dashboard.posts.update');
     Route::delete('/dashboard/posts/{post}', [PostController::class, 'destroy'])->name('dashboard.posts.destroy');
+    // Advertisement management routes
+    Route::get('/dashboard/ads', [AdvertisementController::class, 'index'])->name('dashboard.ads');
+    Route::get('/dashboard/ads/create', [AdvertisementController::class, 'create'])->name('dashboard.ads.create');
+    Route::post('/dashboard/ads', [AdvertisementController::class, 'store'])->name('dashboard.ads.store');
+    Route::get('/dashboard/ads/{ad}/edit', [AdvertisementController::class, 'edit'])->name('dashboard.ads.edit');
+    Route::put('/dashboard/ads/{ad}', [AdvertisementController::class, 'update'])->name('dashboard.ads.update');
+    Route::delete('/dashboard/ads/{ad}', [AdvertisementController::class, 'destroy'])->name('dashboard.ads.destroy');
     Route::get('/dashboard/users', [DashboardController::class, 'users'])->name('dashboard.users');
 });
 

--- a/guhso-backend/tests/Feature/AdvertisementControllerTest.php
+++ b/guhso-backend/tests/Feature/AdvertisementControllerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Advertisement;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class AdvertisementControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_store_calculates_end_at_from_duration(): void
+    {
+        Sanctum::actingAs(User::factory()->create(['role' => 'admin']));
+
+        $response = $this->postJson('/api/v1/admin/ads', [
+            'title' => 'Test Ad',
+            'duration_days' => 5,
+            'start_at' => '2025-01-01 08:00:00',
+        ]);
+
+        $response->assertStatus(201)->assertJsonFragment(['title' => 'Test Ad']);
+
+        $ad = Advertisement::first();
+        $this->assertEquals('2025-01-01 08:00:00', $ad->start_at->format('Y-m-d H:i:s'));
+        $this->assertEquals('2025-01-06 08:00:00', $ad->end_at->format('Y-m-d H:i:s'));
+    }
+
+    public function test_active_endpoint_returns_only_current_ads(): void
+    {
+        Advertisement::factory()->create([
+            'title' => 'Active Ad',
+            'start_at' => now()->subDay(),
+            'end_at' => now()->addDay(),
+            'is_active' => true,
+        ]);
+
+        Advertisement::factory()->create([
+            'title' => 'Expired Ad',
+            'start_at' => now()->subDays(5),
+            'end_at' => now()->subDay(),
+            'is_active' => true,
+        ]);
+
+        $response = $this->getJson('/api/v1/ads');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(1);
+        $response->assertJsonFragment(['title' => 'Active Ad']);
+    }
+}


### PR DESCRIPTION
## Summary
- add admin-side advertisement CRUD controller and views
- route dashboard links and sidebar tab for managing ads

## Testing
- `composer install` *(fails: GitHub API requires authentication token)*
- `DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_689df6a808d88326886e68fa377bed24