### PR TITLE
fix: derive API base URL from current origin

### DIFF
--- a/guhso-podcast-react/src/api.js
+++ b/guhso-podcast-react/src/api.js
@@ -1,4 +1,12 @@
-const API_URL = process.env.REACT_APP_API_URL || 'https://guhso.com/api/v1';
+// Determine API base URL.
+// Use explicit environment variable when provided. Otherwise,
+// fall back to the current origin so development and production
+// builds hit the same host the app is served from.
+const API_URL =
+  process.env.REACT_APP_API_URL ||
+  (typeof window !== 'undefined'
+    ? `${window.location.origin.replace(/\/$/, '')}/api/v1`
+    : '/api/v1');
 
 /**
  * Process episode data to normalize thumbnail fields


### PR DESCRIPTION
## Summary
- Determine API base URL from `REACT_APP_API_URL` or current site origin

## Testing
- `CI=true npm test --silent`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689f08f71e7483269202abf26e5bca07