### PR TITLE
Point frontend to kjprocleaning API and allow CORS

### DIFF
--- a/guhso-backend/config/cors.php
+++ b/guhso-backend/config/cors.php
@@ -21,8 +21,10 @@ return [
 
     // 'allowed_origins' => ['*'],
     'allowed_origins' => [
-    'http://localhost:3000',    // Your React app
-    'http://127.0.0.1:3000',
+        'http://localhost:3000',    // Local React app
+        'http://127.0.0.1:3000',
+        'https://guhso.com',       // Production frontend
+        'https://www.guhso.com',
     ],
 
     'allowed_origins_patterns' => [],

--- a/guhso-podcast-react/DEPLOYMENT.md
+++ b/guhso-podcast-react/DEPLOYMENT.md
@@ -135,7 +135,7 @@ sharp -i original.jpg -o episode-1-large.jpg --width 800 --height 600 --quality 
 
 Create `.env.production` in your local project:
 ```env
-REACT_APP_API_URL=https://guhso.com/api/v1
+REACT_APP_API_URL=https://kjprocleaning.com/api/v1
 REACT_APP_CDN_URL=https://guhso.com
 ```
 
@@ -182,7 +182,7 @@ curl -I https://guhso.com/images/thumbnails/default.jpg
 curl -I https://guhso.com/episodes
 
 # Test API endpoints (if applicable)
-curl -I https://guhso.com/api/v1/episodes
+curl -I https://kjprocleaning.com/api/v1/episodes
 ```
 
 ### Browser Testing:

--- a/guhso-podcast-react/src/api.js
+++ b/guhso-podcast-react/src/api.js
@@ -1,12 +1,9 @@
 // Determine API base URL.
-// Use explicit environment variable when provided. Otherwise,
-// fall back to the current origin so development and production
-// builds hit the same host the app is served from.
-const API_URL =
-  process.env.REACT_APP_API_URL ||
-  (typeof window !== 'undefined'
-    ? `${window.location.origin.replace(/\/$/, '')}/api/v1`
-    : '/api/v1');
+// Prefer an explicit environment variable. If none is provided,
+// default to the production API hosted at kjprocleaning.com so the
+// public site served from guhso.com can reach the backend.
+export const API_URL =
+  process.env.REACT_APP_API_URL || 'https://kjprocleaning.com/api/v1';
 
 /**
  * Process episode data to normalize thumbnail fields

--- a/guhso-podcast-react/src/services/emailService.js
+++ b/guhso-podcast-react/src/services/emailService.js
@@ -1,9 +1,10 @@
 // src/services/emailService.js
 import { generateDonationConfirmationEmail, generatePlainTextConfirmation } from '../templates/donationConfirmationEmail';
+import { API_URL } from '../api';
 
 class EmailService {
   constructor() {
-    this.apiUrl = process.env.REACT_APP_API_URL || 'https://guhso.com/api/v1';
+    this.apiUrl = API_URL;
   }
 
   /**

--- a/guhso-podcast-react/src/services/squarePayment.js
+++ b/guhso-podcast-react/src/services/squarePayment.js
@@ -1,4 +1,5 @@
 // src/services/squarePayment.js
+import { API_URL } from '../api';
 
 class SquarePaymentService {
   constructor() {
@@ -84,7 +85,7 @@ class SquarePaymentService {
         const token = tokenResult.token;
         
         // Send payment data to your backend
-        const response = await fetch('/api/v1/donations/process-payment', {
+        const response = await fetch(`${API_URL}/donations/process-payment`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -132,7 +133,7 @@ class SquarePaymentService {
         const token = tokenResult.token;
         
         // Send subscription data to your backend
-        const response = await fetch('/api/v1/donations/create-subscription', {
+        const response = await fetch(`${API_URL}/donations/create-subscription`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- default React API base to kjprocleaning.com and expose constant
- use shared API base for payment and email services
- permit guhso.com origin through Laravel CORS config

## Testing
- `npm test -- --watchAll=false`
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_689f73b0ddd48326a1cb84d53b0e713a