### PR TITLE
Use local icons in PWA manifest

### DIFF
--- a/guhso-podcast-react/public/manifest.json
+++ b/guhso-podcast-react/public/manifest.json
@@ -3,17 +3,17 @@
   "name": "Create Guhso Podcast App",
   "icons": [
     {
-      "src": "favicon.ico",
+      "src": "/favicon.ico",
       "sizes": "64x64 32x32 24x24 16x16",
       "type": "image/x-icon"
     },
     {
-      "src": "logo.png",
+      "src": "/logo192.png",
       "type": "image/png",
       "sizes": "192x192"
     },
     {
-      "src": "logo512.jpg",
+      "src": "/logo512.png",
       "type": "image/png",
       "sizes": "512x512"
     }


### PR DESCRIPTION
## Summary
- reference local `/logo192.png` and `/logo512.png` in the PWA manifest
- ensure each manifest icon entry includes the correct size and type

## Testing
- `CI=true npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3cdc9f200832698b556ea8063646d