### PR TITLE
Fix donation button navigation to prevent double redirects

### DIFF
--- a/guhso-podcast-react/src/components/Layout/Navbar.js
+++ b/guhso-podcast-react/src/components/Layout/Navbar.js
@@ -8,10 +8,8 @@ const Navbar = () => {
   const navigate = useNavigate();
 
   const handleBigupClick = () => {
-    // Handle registration/donation logic here
+    // Navigate to the donation page
     navigate('/donation');
-    // Handle donation/donation logic here
-    window.location.href = '/donation';
   };
 
   const toggleMobileMenu = () => {


### PR DESCRIPTION
## Summary
- Use React Router's navigate for donation button

## Testing
- `npm test -- --watchAll=false`
- `curl -sI http://localhost:3000/donation`


------
https://chatgpt.com/codex/tasks/task_e_68a3d75337188326ae3e45ad9b21207e