### PR TITLE
feat: improve vertical volume slider

### DIFF
--- a/guhso-podcast-react/src/components/Player/FloatingPlayer.css
+++ b/guhso-podcast-react/src/components/Player/FloatingPlayer.css
@@ -314,8 +314,8 @@
 }
 
 .volume-slider input[type="range"] {
-    writing-mode: bt-lr; /* IE */
-    -webkit-appearance: slider-vertical; /* WebKit */
+    writing-mode: vertical-lr;
+    direction: rtl;
     width: 30px;
     height: 100px;
     background: transparent;


### PR DESCRIPTION
## Summary
- switch volume slider to cross-browser vertical orientation without vendor-specific appearance

## Testing
- `npm test -- --watchAll=false`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3f32a7074832688cc666d4863e1e2