### PR TITLE
Run auto-advance effect regardless of content

### DIFF
--- a/guhso-podcast-react/src/components/Sidebar/FeaturedSection.js
+++ b/guhso-podcast-react/src/components/Sidebar/FeaturedSection.js
@@ -28,6 +28,14 @@ const FeaturedSection = () => {
     );
   };
 
+  useEffect(() => {
+    if (!featuredItems.length) return;
+    const interval = setInterval(() => {
+      setActiveDot((prev) => (prev + 1) % featuredItems.length);
+    }, 25000);
+    return () => clearInterval(interval);
+  }, [featuredItems.length]);
+
   if (!featuredItems.length) {
     return null;
   }
@@ -67,14 +75,6 @@ const FeaturedSection = () => {
     }
     startXRef.current = null;
   };
-
-  useEffect(() => {
-    if (!featuredItems.length) return;
-    const interval = setInterval(() => {
-      setActiveDot((prev) => (prev + 1) % featuredItems.length);
-    }, 25000);
-    return () => clearInterval(interval);
-  }, [featuredItems.length]);
 
   const imageUrl =
     activePost.thumbnail_url ||


### PR DESCRIPTION
## Summary
- Move slide auto-advance effect above early return so all hooks run each render
- Guard interval effect against empty featuredItems to avoid setting unnecessary timers

## Testing
- `cd guhso-podcast-react && npm test -- --watchAll=false`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f329ebe48326b678a28bb442a80a