### PR TITLE
Add product management to dashboard

### DIFF
--- a/guhso-backend/app/Http/Controllers/ProductController.php
+++ b/guhso-backend/app/Http/Controllers/ProductController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Product;
+use App\Models\ProductVariant;
+use App\Models\Color;
+use App\Models\Size;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class ProductController extends Controller
+{
+    public function index()
+    {
+        $products = Product::with('variants')->get();
+        $totalProducts = $products->count();
+        $outOfStock = $products->filter(fn($p) => $p->variants->sum('stock_qty') <= 0)->count();
+
+        return view('dashboard.products.index', compact('products', 'totalProducts', 'outOfStock'));
+    }
+
+    public function create()
+    {
+        return view('dashboard.products.create');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'slug' => 'nullable|string|max:255|unique:products,slug',
+            'subtitle' => 'nullable|string|max:255',
+            'description_md' => 'nullable|string',
+            'details_md' => 'nullable|string',
+            'care_md' => 'nullable|string',
+            'base_price' => 'required|numeric',
+            'inventory_badge' => 'nullable|string|max:255',
+            'active' => 'boolean',
+            'sku' => 'required|string|max:255|unique:product_variants,sku',
+            'variant_price' => 'nullable|numeric',
+            'stock_qty' => 'required|integer|min:0',
+        ]);
+
+        $data['slug'] = $data['slug'] ?? Str::slug($data['name']);
+        $data['active'] = $request->has('active');
+
+        $product = Product::create([
+            'slug' => $data['slug'],
+            'name' => $data['name'],
+            'subtitle' => $data['subtitle'] ?? null,
+            'description_md' => $data['description_md'] ?? null,
+            'details_md' => $data['details_md'] ?? null,
+            'care_md' => $data['care_md'] ?? null,
+            'base_price' => $data['base_price'],
+            'inventory_badge' => $data['inventory_badge'] ?? null,
+            'active' => $data['active'],
+        ]);
+
+        $color = Color::firstOrCreate(
+            ['slug' => 'default'],
+            ['name' => 'Default', 'hex' => '#000000', 'is_default' => true]
+        );
+
+        $size = Size::firstOrCreate(
+            ['label' => 'One Size'],
+            ['sort_order' => 1, 'active' => true]
+        );
+
+        ProductVariant::create([
+            'product_id' => $product->id,
+            'color_id' => $color->id,
+            'size_id' => $size->id,
+            'sku' => $data['sku'],
+            'price' => $data['variant_price'] ?? null,
+            'stock_qty' => $data['stock_qty'],
+        ]);
+
+        return redirect()->route('dashboard.products')->with('status', 'Product created successfully.');
+    }
+}

--- a/guhso-backend/app/Models/Color.php
+++ b/guhso-backend/app/Models/Color.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Color extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'slug',
+        'hex',
+        'is_default',
+    ];
+
+    protected $casts = [
+        'is_default' => 'boolean',
+    ];
+
+    public function variants(): HasMany
+    {
+        return $this->hasMany(ProductVariant::class);
+    }
+}

--- a/guhso-backend/app/Models/Product.php
+++ b/guhso-backend/app/Models/Product.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Product extends Model
+{
+    use HasFactory, HasUlids;
+
+    protected $fillable = [
+        'slug',
+        'name',
+        'subtitle',
+        'description_md',
+        'details_md',
+        'care_md',
+        'base_price',
+        'active',
+        'inventory_badge',
+    ];
+
+    protected $casts = [
+        'active' => 'boolean',
+        'base_price' => 'decimal:2',
+    ];
+
+    public function variants(): HasMany
+    {
+        return $this->hasMany(ProductVariant::class);
+    }
+
+    public function images(): HasMany
+    {
+        return $this->hasMany(ProductImage::class);
+    }
+
+    public function getTotalStockAttribute(): int
+    {
+        return $this->variants->sum('stock_qty');
+    }
+
+    public function getIsOutOfStockAttribute(): bool
+    {
+        return $this->total_stock <= 0;
+    }
+}

--- a/guhso-backend/app/Models/ProductImage.php
+++ b/guhso-backend/app/Models/ProductImage.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ProductImage extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'product_id',
+        'variant_id',
+        'alt_text',
+        'sort_order',
+        'storage_key',
+        'cdn_url_original',
+        'cdn_url_lg',
+        'cdn_url_md',
+        'cdn_url_sm',
+        'cdn_url_thumb',
+        'cdn_url_webp_lg',
+        'cdn_url_webp_md',
+        'cdn_url_webp_sm',
+        'cdn_url_webp_thumb',
+        'width',
+        'height',
+        'dominant_hex',
+        'blurhash',
+    ];
+
+    protected $casts = [
+        'sort_order' => 'integer',
+        'width' => 'integer',
+        'height' => 'integer',
+    ];
+
+    public function product(): BelongsTo
+    {
+        return $this->belongsTo(Product::class);
+    }
+
+    public function variant(): BelongsTo
+    {
+        return $this->belongsTo(ProductVariant::class, 'variant_id');
+    }
+}

--- a/guhso-backend/app/Models/ProductVariant.php
+++ b/guhso-backend/app/Models/ProductVariant.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class ProductVariant extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'product_id',
+        'color_id',
+        'size_id',
+        'sku',
+        'barcode',
+        'price',
+        'stock_qty',
+        'weight_grams',
+    ];
+
+    protected $casts = [
+        'price' => 'decimal:2',
+        'stock_qty' => 'integer',
+        'weight_grams' => 'integer',
+    ];
+
+    public function product(): BelongsTo
+    {
+        return $this->belongsTo(Product::class);
+    }
+
+    public function color(): BelongsTo
+    {
+        return $this->belongsTo(Color::class);
+    }
+
+    public function size(): BelongsTo
+    {
+        return $this->belongsTo(Size::class);
+    }
+
+    public function images(): HasMany
+    {
+        return $this->hasMany(ProductImage::class, 'variant_id');
+    }
+}

--- a/guhso-backend/app/Models/Size.php
+++ b/guhso-backend/app/Models/Size.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Size extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'label',
+        'sort_order',
+        'active',
+    ];
+
+    protected $casts = [
+        'active' => 'boolean',
+        'sort_order' => 'integer',
+    ];
+
+    public function variants(): HasMany
+    {
+        return $this->hasMany(ProductVariant::class);
+    }
+}

--- a/guhso-backend/database/migrations/2025_08_20_000000_create_products_table.php
+++ b/guhso-backend/database/migrations/2025_08_20_000000_create_products_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('products', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->string('slug')->unique();
+            $table->string('name');
+            $table->string('subtitle')->nullable();
+            $table->longText('description_md')->nullable();
+            $table->longText('details_md')->nullable();
+            $table->longText('care_md')->nullable();
+            $table->decimal('base_price', 10, 2)->default(0);
+            $table->boolean('active')->default(true);
+            $table->string('inventory_badge')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('products');
+    }
+};

--- a/guhso-backend/database/migrations/2025_08_20_000100_create_colors_table.php
+++ b/guhso-backend/database/migrations/2025_08_20_000100_create_colors_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('colors', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->string('hex');
+            $table->boolean('is_default')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('colors');
+    }
+};

--- a/guhso-backend/database/migrations/2025_08_20_000200_create_sizes_table.php
+++ b/guhso-backend/database/migrations/2025_08_20_000200_create_sizes_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('sizes', function (Blueprint $table) {
+            $table->id();
+            $table->string('label');
+            $table->integer('sort_order');
+            $table->boolean('active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sizes');
+    }
+};

--- a/guhso-backend/database/migrations/2025_08_20_000300_create_product_variants_table.php
+++ b/guhso-backend/database/migrations/2025_08_20_000300_create_product_variants_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('product_variants', function (Blueprint $table) {
+            $table->id();
+            $table->ulid('product_id');
+            $table->foreign('product_id')->references('id')->on('products')->cascadeOnDelete();
+            $table->foreignId('color_id')->constrained('colors');
+            $table->foreignId('size_id')->constrained('sizes');
+            $table->string('sku')->unique();
+            $table->string('barcode')->nullable();
+            $table->decimal('price', 10, 2)->nullable();
+            $table->integer('stock_qty')->default(0);
+            $table->integer('weight_grams')->nullable();
+            $table->timestamps();
+            $table->unique(['product_id', 'color_id', 'size_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('product_variants');
+    }
+};

--- a/guhso-backend/database/migrations/2025_08_20_000400_create_product_images_table.php
+++ b/guhso-backend/database/migrations/2025_08_20_000400_create_product_images_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('product_images', function (Blueprint $table) {
+            $table->id();
+            $table->ulid('product_id');
+            $table->foreign('product_id')->references('id')->on('products')->cascadeOnDelete();
+            $table->foreignId('variant_id')->nullable()->constrained('product_variants');
+            $table->string('alt_text')->nullable();
+            $table->integer('sort_order')->default(0);
+            $table->string('storage_key');
+            $table->string('cdn_url_original');
+            $table->string('cdn_url_lg')->nullable();
+            $table->string('cdn_url_md')->nullable();
+            $table->string('cdn_url_sm')->nullable();
+            $table->string('cdn_url_thumb')->nullable();
+            $table->string('cdn_url_webp_lg')->nullable();
+            $table->string('cdn_url_webp_md')->nullable();
+            $table->string('cdn_url_webp_sm')->nullable();
+            $table->string('cdn_url_webp_thumb')->nullable();
+            $table->integer('width')->nullable();
+            $table->integer('height')->nullable();
+            $table->string('dominant_hex')->nullable();
+            $table->text('blurhash')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('product_images');
+    }
+};

--- a/guhso-backend/resources/views/dashboard/layout.blade.php
+++ b/guhso-backend/resources/views/dashboard/layout.blade.php
@@ -71,6 +71,10 @@
                             <i class="fas fa-bullhorn nav-icon" style="margin-right: 16px;"></i>
                             <span>Advertisements</span>
                         </a>
+                        <a href="{{ route('dashboard.products') }}" class="nav-link {{ request()->routeIs('dashboard.products*') ? 'active' : '' }}">
+                            <i class="fas fa-box nav-icon" style="margin-right: 16px;"></i>
+                            <span>Products</span>
+                        </a>
                         <a href="{{ route('dashboard.users') }}" class="nav-link {{ request()->routeIs('dashboard.users') ? 'active' : '' }}">
                             <i class="fas fa-users nav-icon" style="margin-right: 16px;"></i>
                             <span>Users</span>

--- a/guhso-backend/resources/views/dashboard/products/create.blade.php
+++ b/guhso-backend/resources/views/dashboard/products/create.blade.php
@@ -1,0 +1,72 @@
+@extends('dashboard.layout')
+
+@section('title', 'Create Product - Guhso Dashboard')
+
+@section('content')
+<h1 class="text-2xl font-semibold text-gray-900 mb-4">Create Product</h1>
+
+@if ($errors->any())
+    <div class="bg-red-100 text-red-700 p-2 mb-4">
+        <ul class="list-disc pl-5">
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
+
+<form method="POST" action="{{ route('dashboard.products.store') }}" class="space-y-4">
+    @csrf
+    <div>
+        <label class="block mb-1">Name</label>
+        <input type="text" name="name" value="{{ old('name') }}" class="w-full border px-3 py-2" />
+    </div>
+    <div>
+        <label class="block mb-1">Slug</label>
+        <input type="text" name="slug" value="{{ old('slug') }}" class="w-full border px-3 py-2" />
+    </div>
+    <div>
+        <label class="block mb-1">Subtitle</label>
+        <input type="text" name="subtitle" value="{{ old('subtitle') }}" class="w-full border px-3 py-2" />
+    </div>
+    <div>
+        <label class="block mb-1">Base Price</label>
+        <input type="number" step="0.01" name="base_price" value="{{ old('base_price') }}" class="w-full border px-3 py-2" />
+    </div>
+    <div>
+        <label class="block mb-1">Inventory Badge</label>
+        <input type="text" name="inventory_badge" value="{{ old('inventory_badge') }}" class="w-full border px-3 py-2" />
+    </div>
+    <div>
+        <label class="block mb-1">Description</label>
+        <textarea name="description_md" class="w-full border px-3 py-2">{{ old('description_md') }}</textarea>
+    </div>
+    <div>
+        <label class="block mb-1">Details</label>
+        <textarea name="details_md" class="w-full border px-3 py-2">{{ old('details_md') }}</textarea>
+    </div>
+    <div>
+        <label class="block mb-1">Care</label>
+        <textarea name="care_md" class="w-full border px-3 py-2">{{ old('care_md') }}</textarea>
+    </div>
+    <div>
+        <label class="block mb-1">SKU</label>
+        <input type="text" name="sku" value="{{ old('sku') }}" class="w-full border px-3 py-2" />
+    </div>
+    <div>
+        <label class="block mb-1">Variant Price</label>
+        <input type="number" step="0.01" name="variant_price" value="{{ old('variant_price') }}" class="w-full border px-3 py-2" />
+    </div>
+    <div>
+        <label class="block mb-1">Stock Quantity</label>
+        <input type="number" name="stock_qty" value="{{ old('stock_qty') }}" class="w-full border px-3 py-2" />
+    </div>
+    <div class="flex items-center">
+        <input type="checkbox" name="active" value="1" class="mr-2" {{ old('active', true) ? 'checked' : '' }} />
+        <label>Active</label>
+    </div>
+    <div>
+        <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Save</button>
+    </div>
+</form>
+@endsection

--- a/guhso-backend/resources/views/dashboard/products/index.blade.php
+++ b/guhso-backend/resources/views/dashboard/products/index.blade.php
@@ -1,0 +1,45 @@
+@extends('dashboard.layout')
+
+@section('title', 'Products - Guhso Dashboard')
+
+@section('content')
+<div class="mb-6">
+    <h1 class="text-2xl font-semibold text-gray-900 mb-2">Products</h1>
+    <div class="flex space-x-4 text-sm text-gray-700">
+        <span>Total Products: {{ $totalProducts }}</span>
+        <span>Out of Stock: {{ $outOfStock }}</span>
+    </div>
+    <div class="mt-4">
+        <a href="{{ route('dashboard.products.create') }}" class="bg-blue-500 text-white px-4 py-2 rounded">Create Product</a>
+    </div>
+</div>
+
+@if(session('status'))
+    <div class="bg-green-100 text-green-700 p-2 mb-4">{{ session('status') }}</div>
+@endif
+
+<table class="min-w-full bg-white rounded shadow">
+    <thead>
+        <tr>
+            <th class="px-4 py-2 text-left">Name</th>
+            <th class="px-4 py-2 text-left">Price</th>
+            <th class="px-4 py-2 text-left">Stock</th>
+            <th class="px-4 py-2 text-left">Active</th>
+        </tr>
+    </thead>
+    <tbody>
+        @forelse($products as $product)
+            <tr class="border-t">
+                <td class="px-4 py-2">{{ $product->name }}</td>
+                <td class="px-4 py-2">${{ number_format($product->base_price, 2) }}</td>
+                <td class="px-4 py-2">{{ $product->variants->sum('stock_qty') }}</td>
+                <td class="px-4 py-2">{{ $product->active ? 'Yes' : 'No' }}</td>
+            </tr>
+        @empty
+            <tr>
+                <td colspan="4" class="px-4 py-4 text-center text-gray-500">No products found.</td>
+            </tr>
+        @endforelse
+    </tbody>
+</table>
+@endsection

--- a/guhso-backend/routes/web.php
+++ b/guhso-backend/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Admin\PostController;
 use App\Http\Controllers\Admin\AdvertisementController;
 use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\MailingListController;
+use App\Http\Controllers\ProductController;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Validator;
@@ -109,6 +110,9 @@ Route::middleware('auth')->group(function () {
     Route::get('/dashboard/ads/{ad}/edit', [AdvertisementController::class, 'edit'])->name('dashboard.ads.edit');
     Route::put('/dashboard/ads/{ad}', [AdvertisementController::class, 'update'])->name('dashboard.ads.update');
     Route::delete('/dashboard/ads/{ad}', [AdvertisementController::class, 'destroy'])->name('dashboard.ads.destroy');
+    Route::get('/dashboard/products', [ProductController::class, 'index'])->name('dashboard.products');
+    Route::get('/dashboard/products/create', [ProductController::class, 'create'])->name('dashboard.products.create');
+    Route::post('/dashboard/products', [ProductController::class, 'store'])->name('dashboard.products.store');
     Route::get('/dashboard/users', [DashboardController::class, 'users'])->name('dashboard.users');
     Route::get('/dashboard/mailing-list', [MailingListController::class, 'index'])->name('dashboard.mailing-list');
     Route::post('/dashboard/mailing-list/send', [MailingListController::class, 'send'])->name('dashboard.mailing-list.send');


### PR DESCRIPTION
## Summary
- add database structure for products, variants, colors, sizes and images
- expose product listing and creation on dashboard with counts and stock handling
- wire products tab into dashboard navigation and routes

## Testing
- `php -l app/Http/Controllers/ProductController.php app/Models/Product.php app/Models/Color.php app/Models/Size.php app/Models/ProductVariant.php app/Models/ProductImage.php database/migrations/2025_08_20_000000_create_products_table.php database/migrations/2025_08_20_000100_create_colors_table.php database/migrations/2025_08_20_000200_create_sizes_table.php database/migrations/2025_08_20_000300_create_product_variants_table.php database/migrations/2025_08_20_000400_create_product_images_table.php`
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a35fd49c9483269a907ec2acbdd492