### PR TITLE
chore: update API URL to production domain

### DIFF
--- a/guhso-podcast-react/.env
+++ b/guhso-podcast-react/.env
@@ -1,4 +1,4 @@
-REACT_APP_API_URL=http://localhost:8000/api/v1
+REACT_APP_API_URL=http://kjprocleaning.com/api/v1
 REACT_APP_APP_NAME=Guhso
 REACT_APP_ENVIRONMENT=production
 


### PR DESCRIPTION
## Summary
- point API URL to `kjprocleaning.com`

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7733e1a188326873d02cd63f13c28